### PR TITLE
Feat: Add initial Cognitive Module Library interfaces for memory

### DIFF
--- a/PiaAGI_Hub/cognitive_module_library/README.md
+++ b/PiaAGI_Hub/cognitive_module_library/README.md
@@ -1,0 +1,45 @@
+# PiaAGI Cognitive Module Library (CML)
+
+## Purpose
+
+The Cognitive Module Library (CML) is a core component of the PiaAGI project. Its primary purpose is to define abstract interfaces and, eventually, provide foundational Python implementations for the various cognitive modules outlined in the [PiaAGI Cognitive Architecture](../../PiaAGI.md#4-the-piaagi-cognitive-architecture).
+
+This library aims to:
+1.  **Standardize Interfaces:** Provide common Python Abstract Base Classes (ABCs) for each cognitive module, ensuring that different implementations of a module can be used interchangeably within the broader PiaAGI framework.
+2.  **Facilitate Modular Development:** Allow researchers and developers to focus on specific cognitive functions by working on individual modules.
+3.  **Support Simulation and Experimentation:** Enable the construction of PiaAGI agent simulations by composing these modules, as demonstrated conceptually in `PiaAGI_Hub/conceptual_simulations/PiaAGI_Behavior_Example.py`.
+4.  **Promote Code Reusability:** Offer well-documented and tested base components that can be extended or used directly in more complex AGI implementations.
+5.  **Align with Theory:** Ensure that module designs and interfaces are closely mapped to the theoretical descriptions in the main `PiaAGI.md` document.
+
+## Current Modules (Abstract Interfaces)
+
+This initial version of the CML provides abstract base classes for the following memory-related modules:
+
+1.  **`base_memory_module.py` (`BaseMemoryModule`)**:
+    *   **Purpose:** Defines the fundamental interface common to all memory systems within PiaAGI. It outlines core operations like storing information, retrieving it based on queries, managing memory capacity, and handling forgetting.
+    *   **PiaAGI.md Sections:** 3.1.1 (Memory Systems), 4.1.2 (Working Memory Module), 4.1.3 (Long-Term Memory Module).
+
+2.  **`long_term_memory_module.py` (`LongTermMemoryModule`)**:
+    *   **Purpose:** Extends `BaseMemoryModule` to define the interface for Long-Term Memory. LTM is the AGI's vast repository for semantic knowledge, episodic experiences, and procedural skills. This interface includes methods specific to these LTM sub-components.
+    *   **PiaAGI.md Sections:** 3.1.1 (LTM details), 4.1.3 (Long-Term Memory Module).
+
+3.  **`working_memory_module.py` (`WorkingMemoryModule`)**:
+    *   **Purpose:** Extends `BaseMemoryModule` to define the interface for Working Memory. WM is a limited-capacity system for temporarily holding and actively processing information relevant to current tasks. It also conceptually includes functions of the Central Executive (attention, coordination).
+    *   **PiaAGI.md Sections:** 3.1.1 (WM details), 3.1.2 (Attention and Cognitive Control/Central Executive), 4.1.2 (Working Memory Module).
+
+## Future Development
+
+The CML will be expanded to include interfaces and foundational implementations for other core PiaAGI cognitive modules, such as:
+*   Perception Module
+*   Attention Module
+*   Learning Module(s)
+*   Motivational System Module
+*   Emotion Module
+*   Planning and Decision-Making Module
+*   Behavior Generation Module
+*   Self-Model Module
+*   Theory of Mind (ToM) / Social Cognition Module
+*   Communication Module
+
+Contributions and collaborations are welcome as this library evolves.
+```

--- a/PiaAGI_Hub/cognitive_module_library/base_memory_module.py
+++ b/PiaAGI_Hub/cognitive_module_library/base_memory_module.py
@@ -1,0 +1,169 @@
+from abc import ABC, abstractmethod
+
+class BaseMemoryModule(ABC):
+    """
+    Abstract Base Class for all memory modules within the PiaAGI Cognitive Architecture.
+
+    This class defines the common interface that all memory components (e.g., LTM, WM, Sensory Memory)
+    should adhere to, ensuring a consistent way for the AGI to interact with its memory systems.
+    The specific implementation of these methods will vary greatly depending on the type of memory
+    and the chosen computational model.
+
+    Refer to PiaAGI.md Sections 3.1.1 (Memory Systems) and 4.1.3 (Long-Term Memory Module)
+    and 4.1.2 (Working Memory Module) for more context.
+    """
+
+    @abstractmethod
+    def store(self, information: dict, context: dict = None) -> bool:
+        """
+        Stores information into the memory module.
+
+        The 'information' itself is expected to be a structured dict, but its exact content
+        will depend on the type of memory (e.g., semantic fact, episodic event, procedural skill).
+        'context' provides additional metadata (e.g., timestamp, emotional valence, source)
+        that can be crucial for retrieval and memory management.
+
+        Args:
+            information (dict): The data to be stored. Structure depends on memory type.
+                                Example for a semantic memory:
+                                {'type': 'semantic', 'concept': 'PiaAGI', 'relation': 'is_a', 'value': 'cognitive_architecture'}
+                                Example for an episodic memory:
+                                {'type': 'episode', 'event': 'user_greeted', 'timestamp': 12345.67, 'actors': ['user', 'self']}
+            context (dict, optional): Additional contextual information about the information being stored.
+                                      This can include temporal tags, emotional tags, source, relevance, etc.
+                                      Example: {'timestamp': 1234567890.0, 'source': 'PerceptionModule', 'emotion_valence': 0.7}
+
+        Returns:
+            bool: True if storage was successful, False otherwise.
+        """
+        pass
+
+    @abstractmethod
+    def retrieve(self, query: dict, criteria: dict = None) -> list[dict]:
+        """
+        Retrieves information from the memory module based on a query and criteria.
+
+        The 'query' specifies what information is being sought.
+        'criteria' can refine the search (e.g., recency, relevance, emotional match).
+
+        Args:
+            query (dict): The query specifying the information to retrieve.
+                          Example: {'concept': 'PiaAGI', 'relation': 'is_a'}
+                          Example: {'event_type': 'user_interaction', 'last_n': 5}
+            criteria (dict, optional): Additional criteria to guide the retrieval process.
+                                       Example: {'min_relevance': 0.8, 'max_recency_days': 7, 'match_emotion': 'positive'}
+
+        Returns:
+            list[dict]: A list of information items matching the query and criteria.
+                        Each item is a dict, similar in structure to what was stored.
+                        Returns an empty list if no information is found.
+        """
+        pass
+
+    @abstractmethod
+    def manage_capacity(self) -> None:
+        """
+        Manages the memory module's capacity.
+
+        This can involve processes like consolidating less important information,
+        archiving old data, or other strategies to prevent overload, depending on
+        the memory type (e.g., WM has very limited capacity, LTM is vast but might
+        still need optimization).
+
+        This method might be called periodically by the AGI's Central Executive or
+        triggered by internal state (e.g., high cognitive load in WM).
+        """
+        pass
+
+    @abstractmethod
+    def handle_forgetting(self, strategy: str = 'default') -> None:
+        """
+        Implements forgetting mechanisms to remove or weaken irrelevant or outdated information.
+
+        Forgetting is crucial for adaptive intelligence, preventing interference and
+        keeping knowledge relevant. Strategies could include decay over time,
+        interference-based forgetting, or targeted removal based on utility.
+
+        Args:
+            strategy (str, optional): Specifies the forgetting strategy to apply.
+                                      Examples: 'decay', 'interference_pruning', 'utility_based'.
+                                      Defaults to 'default'.
+        """
+        pass
+
+    @abstractmethod
+    def get_status(self) -> dict:
+        """
+        Returns the current status of the memory module.
+
+        This could include information like current capacity usage, number of items,
+        average retrieval time, health metrics, etc. Useful for the Self-Model
+        and for debugging or analysis.
+
+        Returns:
+            dict: A dictionary containing status information.
+                  Example: {'capacity_percentage': 65.5, 'total_items': 1500000, 'last_accessed': 'timestamp'}
+        """
+        pass
+
+if __name__ == '__main__':
+    # This section is for conceptual illustration and won't be run directly by other modules.
+    # It shows how one might conceptually think about a concrete implementation,
+    # though BaseMemoryModule itself cannot be instantiated.
+
+    class ConceptualLTM(BaseMemoryModule):
+        def __init__(self):
+            self.storage = {}
+            self.item_id_counter = 0
+            print("ConceptualLTM initialized - A very simplified LTM concept.")
+
+        def store(self, information: dict, context: dict = None) -> bool:
+            print(f"ConceptualLTM: Attempting to store: {information} with context: {context}")
+            self.item_id_counter += 1
+            self.storage[self.item_id_counter] = {'info': information, 'ctx': context or {}}
+            print(f"ConceptualLTM: Stored item with ID {self.item_id_counter}")
+            return True
+
+        def retrieve(self, query: dict, criteria: dict = None) -> list[dict]:
+            print(f"ConceptualLTM: Attempting to retrieve based on query: {query} and criteria: {criteria}")
+            results = []
+            # Highly simplified retrieval: exact match on a 'concept' in information
+            if 'concept' in query:
+                for item_id, stored_item in self.storage.items():
+                    if stored_item['info'].get('concept') == query['concept']:
+                        results.append(stored_item['info'])
+            print(f"ConceptualLTM: Found {len(results)} items.")
+            return results
+
+        def manage_capacity(self) -> None:
+            print("ConceptualLTM: manage_capacity() called. In a real system, this would involve complex processes.")
+            if len(self.storage) > 10: # Arbitrary small capacity for demo
+                print("ConceptualLTM: Capacity potentially exceeded. Forgetting oldest item for demo.")
+                if self.storage:
+                    oldest_item_id = min(self.storage.keys())
+                    del self.storage[oldest_item_id]
+                    print(f"ConceptualLTM: Forgot item with ID {oldest_item_id}")
+
+
+        def handle_forgetting(self, strategy: str = 'default') -> None:
+            print(f"ConceptualLTM: handle_forgetting() called with strategy: {strategy}")
+            # This would be a complex mechanism in a real LTM.
+            pass
+
+        def get_status(self) -> dict:
+            status = {
+                'capacity_percentage': (len(self.storage) / 10.0) * 100 if 10 > 0 else 0, # Conceptual capacity of 10 items
+                'total_items': len(self.storage),
+                'module_type': 'ConceptualLTM'
+            }
+            print(f"ConceptualLTM: Status: {status}")
+            return status
+
+    # Conceptual usage demonstration:
+    ltm_instance = ConceptualLTM()
+    ltm_instance.store({'type': 'semantic', 'concept': 'Dark Matter', 'definition': 'Hypothetical matter not interacting with light.'}, {'source': 'user_input'})
+    ltm_instance.store({'type': 'semantic', 'concept': 'AGI', 'definition': 'Artificial General Intelligence.'})
+    retrieved_info = ltm_instance.retrieve({'concept': 'Dark Matter'})
+    print(f"Retrieved from LTM: {retrieved_info}")
+    ltm_instance.get_status()
+    ltm_instance.manage_capacity() # Potentially forget if capacity is small and exceeded

--- a/PiaAGI_Hub/cognitive_module_library/long_term_memory_module.py
+++ b/PiaAGI_Hub/cognitive_module_library/long_term_memory_module.py
@@ -1,0 +1,254 @@
+from abc import abstractmethod
+from .base_memory_module import BaseMemoryModule # Assuming base_memory_module.py is in the same directory
+
+class LongTermMemoryModule(BaseMemoryModule):
+    """
+    Abstract Base Class for the Long-Term Memory (LTM) module in the PiaAGI Cognitive Architecture.
+
+    LTM is the vast repository for the AGI's knowledge, experiences, and learned skills.
+    It is characterized by its large capacity and persistence of information.
+    This interface builds upon BaseMemoryModule and adds methods specific to the distinct types
+    of information typically stored in LTM: semantic, episodic, and procedural.
+
+    Refer to PiaAGI.md Sections 3.1.1 (Memory Systems - LTM) and 4.1.3 (Long-Term Memory Module)
+    for comprehensive details on LTM's role and sub-components.
+    """
+
+    @abstractmethod
+    def store_semantic_knowledge(self, concept_info: dict, context: dict = None) -> bool:
+        """
+        Stores semantic knowledge (facts, concepts, relations) in LTM.
+        This corresponds to the Semantic Memory sub-component of LTM.
+
+        Args:
+            concept_info (dict): A dictionary representing the semantic information.
+                                 Example: {'concept': 'Sun', 'category': 'Star', 
+                                           'properties': ['hot', 'bright'], 
+                                           'relations': [{'type': 'is_center_of', 'target': 'Solar System'}]}
+            context (dict, optional): Contextual information (e.g., source, certainty).
+
+        Returns:
+            bool: True if storage was successful, False otherwise.
+        """
+        # This internally would call self.store() with appropriate structuring.
+        pass
+
+    @abstractmethod
+    def get_semantic_knowledge(self, concept: str, relations: list = None) -> list[dict]:
+        """
+        Retrieves semantic knowledge related to a given concept.
+
+        Args:
+            concept (str): The concept to query (e.g., "Sun").
+            relations (list, optional): Specific relations to retrieve for the concept. 
+                                        If None, retrieves general information.
+
+        Returns:
+            list[dict]: A list of dictionaries, each representing a piece of semantic knowledge
+                        about the concept. Returns empty list if no knowledge found.
+        """
+        # This internally would use self.retrieve() with appropriate query formulation.
+        pass
+
+    @abstractmethod
+    def store_episodic_experience(self, episode_data: dict, context: dict = None) -> bool:
+        """
+        Stores an episodic experience (a specific event or sequence of events) in LTM.
+        This corresponds to the Episodic Memory sub-component. Episodes are typically
+        time-stamped and associated with specific contexts, actors, and emotional valence.
+
+        Args:
+            episode_data (dict): Data representing the episode.
+                                 Example: {'event_id': 'interaction_001', 'timestamp': 12345.0,
+                                           'type': 'dialogue', 'actors': ['user', 'PiaAGI'],
+                                           'summary': 'User asked about dark matter, PiaAGI responded.',
+                                           'full_log_reference': 'path/to/log_001.txt',
+                                           'emotional_valence_at_encoding': 0.3}
+            context (dict, optional): Broader context if not included in episode_data.
+
+        Returns:
+            bool: True if storage was successful, False otherwise.
+        """
+        pass
+
+    @abstractmethod
+    def get_episodic_experience(self, event_cue: dict, criteria: dict = None) -> list[dict]:
+        """
+        Retrieves episodic experiences based on a cue and criteria.
+        Cues could be related to time, actors, specific events, or emotional valence.
+
+        Args:
+            event_cue (dict): A dictionary specifying cues for retrieval.
+                              Example: {'actor': 'user', 'last_n_interactions': 3}
+                              Example: {'event_type': 'goal_failure', 'related_goal': 'solve_problem_X'}
+            criteria (dict, optional): Additional criteria like time range, emotional similarity.
+
+        Returns:
+            list[dict]: A list of episode data dictionaries.
+        """
+        pass
+
+    @abstractmethod
+    def store_procedural_skill(self, skill_name: str, skill_representation: dict, context: dict = None) -> bool:
+        """
+        Stores procedural knowledge (a skill, habit, or policy) in LTM.
+        This corresponds to the Procedural Memory sub-component.
+
+        Args:
+            skill_name (str): The name of the skill (e.g., "solve_algebra_equation").
+            skill_representation (dict): The representation of the skill. This could be
+                                         a sequence of steps, a script, a learned policy network's
+                                         weights, or another suitable format.
+                                         Example: {'type': 'sequential_steps', 
+                                                   'steps': ['step1_description', 'step2_code_ref']}
+            context (dict, optional): Context like learning source, proficiency level.
+
+        Returns:
+            bool: True if storage was successful, False otherwise.
+        """
+        pass
+
+    @abstractmethod
+    def get_procedural_skill(self, skill_name: str) -> dict:
+        """
+        Retrieves the representation of a specific procedural skill.
+
+        Args:
+            skill_name (str): The name of the skill to retrieve.
+
+        Returns:
+            dict: The skill representation if found, else None or an empty dict.
+        """
+        pass
+
+    @abstractmethod
+    def consolidate_memory(self, type_to_consolidate: str = 'all', intensity: str = 'normal') -> None:
+        """
+        Manages the consolidation of memories within LTM.
+        This is a more specific form of manage_capacity or handle_forgetting,
+        focused on strengthening important memories and integrating new ones
+        with existing knowledge structures, potentially inspired by sleep consolidation.
+
+        Args:
+            type_to_consolidate (str, optional): 'semantic', 'episodic', 'procedural', or 'all'.
+            intensity (str, optional): 'normal', 'high' (e.g., for critical learning periods).
+        """
+        pass
+
+
+if __name__ == '__main__':
+    # Conceptual illustration for LongTermMemoryModule
+    class ConceptualLTMImpl(LongTermMemoryModule):
+        def __init__(self):
+            self.semantic_storage = {}
+            self.episodic_storage = []
+            self.procedural_storage = {}
+            self.item_id_counter = 0
+            print("ConceptualLTMImpl initialized.")
+
+        # --- BaseMemoryModule methods (simplified implementations) ---
+        def store(self, information: dict, context: dict = None) -> bool:
+            # This base store would ideally be called by the specific store_* methods
+            print(f"ConceptualLTMImpl (Base Store): Storing general info: {information}")
+            # For simplicity, we'll just log it here. A real LTM would differentiate.
+            self.item_id_counter +=1
+            # Generic storage for demo if not handled by specific types
+            if information.get('type') not in ['semantic', 'episode', 'skill']:
+                 self.semantic_storage[f"generic_{self.item_id_counter}"] = {'info': information, 'ctx': context or {}}
+            return True
+
+        def retrieve(self, query: dict, criteria: dict = None) -> list[dict]:
+            print(f"ConceptualLTMImpl (Base Retrieve): Retrieving with query: {query}")
+            # Simplified: search across all conceptual storages if not specific
+            results = []
+            if 'concept' in query: # Assume it's a semantic-like query
+                for k, v in self.semantic_storage.items():
+                    if v['info'].get('concept') == query['concept']:
+                        results.append(v['info'])
+            return results
+        
+        def manage_capacity(self) -> None:
+            print("ConceptualLTMImpl: manage_capacity called.")
+            # E.g., check total size, trigger consolidation or pruning if needed
+            pass
+
+        def handle_forgetting(self, strategy: str = 'default') -> None:
+            print(f"ConceptualLTMImpl: handle_forgetting called with strategy {strategy}.")
+            # E.g., implement decay or utility-based removal of old/irrelevant items
+            pass
+        
+        def get_status(self) -> dict:
+            return {
+                'semantic_items': len(self.semantic_storage),
+                'episodic_items': len(self.episodic_storage),
+                'procedural_items': len(self.procedural_storage),
+                'module_type': 'ConceptualLTMImpl'
+            }
+
+        # --- LongTermMemoryModule specific methods ---
+        def store_semantic_knowledge(self, concept_info: dict, context: dict = None) -> bool:
+            print(f"ConceptualLTMImpl: Storing semantic: {concept_info['concept']}")
+            self.semantic_storage[concept_info['concept']] = {'info': concept_info, 'ctx': context or {}}
+            # In a real system, this would call self.store after formatting for internal representation
+            super().store(concept_info, context) # conceptually calling base
+            return True
+
+        def get_semantic_knowledge(self, concept: str, relations: list = None) -> list[dict]:
+            print(f"ConceptualLTMImpl: Retrieving semantic for concept: {concept}")
+            item = self.semantic_storage.get(concept)
+            return [item['info']] if item else []
+
+        def store_episodic_experience(self, episode_data: dict, context: dict = None) -> bool:
+            print(f"ConceptualLTMImpl: Storing episode: {episode_data.get('event_id', 'N/A')}")
+            self.episodic_storage.append({'info': episode_data, 'ctx': context or {}})
+            super().store(episode_data, context) # conceptually calling base
+            return True
+
+        def get_episodic_experience(self, event_cue: dict, criteria: dict = None) -> list[dict]:
+            print(f"ConceptualLTMImpl: Retrieving episodes with cue: {event_cue}")
+            # Highly simplified search
+            results = []
+            if 'actor' in event_cue:
+                for item in self.episodic_storage:
+                    if event_cue['actor'] in item['info'].get('actors', []):
+                        results.append(item['info'])
+            return results
+
+        def store_procedural_skill(self, skill_name: str, skill_representation: dict, context: dict = None) -> bool:
+            print(f"ConceptualLTMImpl: Storing skill: {skill_name}")
+            self.procedural_storage[skill_name] = {'info': skill_representation, 'ctx': context or {}}
+            super().store(skill_representation, context) # conceptually calling base
+            return True
+
+        def get_procedural_skill(self, skill_name: str) -> dict:
+            print(f"ConceptualLTMImpl: Retrieving skill: {skill_name}")
+            item = self.procedural_storage.get(skill_name)
+            return item['info'] if item else {}
+            
+        def consolidate_memory(self, type_to_consolidate: str = 'all', intensity: str = 'normal') -> None:
+            print(f"ConceptualLTMImpl: consolidate_memory called for '{type_to_consolidate}' with intensity '{intensity}'.")
+            # E.g., strengthen links, re-index, prune redundant data
+            pass
+
+    # Conceptual usage:
+    ltm_concrete = ConceptualLTMImpl()
+    ltm_concrete.store_semantic_knowledge(
+        {'concept': 'Photosynthesis', 'category': 'Biology', 'process_description': 'Conversion of light to chemical energy.'},
+        {'source': 'textbook_module_A'}
+    )
+    ltm_concrete.store_episodic_experience(
+        {'event_id': 'sim_001', 'type': 'simulation_run', 'outcome': 'success', 'learnings': 'parameter_X_is_sensitive'},
+        {'timestamp': 12345.678}
+    )
+    ltm_concrete.store_procedural_skill(
+        'greet_user', 
+        {'type': 'script', 'steps': ['identify_user_language', 'select_greeting_template', 'personalize_greeting']},
+        {'version': 1.0}
+    )
+    
+    print(f"Semantic for Photosynthesis: {ltm_concrete.get_semantic_knowledge('Photosynthesis')}")
+    print(f"Episodes with actor 'user_sim': {ltm_concrete.get_episodic_experience({'actor': 'user_sim'})}") # Will be empty
+    print(f"Skill 'greet_user': {ltm_concrete.get_procedural_skill('greet_user')}")
+    print(f"LTM Status: {ltm_concrete.get_status()}")
+
+```

--- a/PiaAGI_Hub/cognitive_module_library/working_memory_module.py
+++ b/PiaAGI_Hub/cognitive_module_library/working_memory_module.py
@@ -1,0 +1,257 @@
+from abc import abstractmethod
+from typing import Any, List, Dict
+from .base_memory_module import BaseMemoryModule # Assuming base_memory_module.py is in the same directory
+
+class WorkingMemoryModule(BaseMemoryModule):
+    """
+    Abstract Base Class for the Working Memory (WM) module in the PiaAGI Cognitive Architecture.
+
+    Working Memory is conceptualized as a limited-capacity system responsible for temporarily
+    holding, processing, and manipulating information relevant to the current cognitive tasks.
+    It acts as a central hub for information from perception, LTM, and for intermediate
+    results of reasoning and planning. The Central Executive is a key component of WM,
+    responsible for attention, control, and coordination.
+
+    Refer to PiaAGI.md Sections 3.1.1 (Memory Systems - WM), 3.1.2 (Attention and Cognitive Control - Central Executive),
+    and 4.1.2 (Working Memory Module) for detailed context.
+    """
+
+    @abstractmethod
+    def add_item_to_workspace(self, item: Any, source_module: str, context: Dict = None) -> bool:
+        """
+        Adds an item to the active workspace of Working Memory.
+
+        Items can be diverse: processed perceptual chunks, retrieved LTM items,
+        intermediate thoughts or hypotheses, goals, etc. The source module helps in
+        tracking information flow and relevance. Context can include priority, saliency.
+
+        Args:
+            item (Any): The information item to add to the workspace.
+                        Its structure will vary (e.g., a dict, a data object).
+            source_module (str): The name of the module providing the item (e.g., "PerceptionModule", "LTMModule").
+            context (Dict, optional): Additional context like priority, saliency, relation to current goal.
+                                      Example: {'priority': 'high', 'saliency': 0.9, 'goal_id': 'goal_001'}
+
+        Returns:
+            bool: True if the item was successfully added, False otherwise (e.g., if WM is at capacity
+                  and cannot make space).
+        """
+        # This would internally call the base `store` method after appropriate formatting for WM.
+        pass
+
+    @abstractmethod
+    def get_workspace_contents(self, criteria: Dict = None) -> List[Any]:
+        """
+        Retrieves items currently active in the workspace, potentially filtered by criteria.
+
+        Args:
+            criteria (Dict, optional): Criteria to filter items, e.g., by source, type, recency.
+                                       Example: {'source_module': 'LTMModule', 'max_age_seconds': 5}
+
+        Returns:
+            List[Any]: A list of items currently in the workspace matching the criteria.
+        """
+        # This would internally call the base `retrieve` method.
+        pass
+
+    @abstractmethod
+    def update_item_in_workspace(self, item_id: Any, new_content: Any = None, new_context: Dict = None) -> bool:
+        """
+        Updates an existing item within the workspace. 
+        This could involve changing its content, its saliency, or other contextual attributes.
+
+        Args:
+            item_id (Any): Identifier for the item to be updated in the workspace.
+            new_content (Any, optional): The new content for the item.
+            new_context (Dict, optional): The new context for the item.
+
+        Returns:
+            bool: True if update was successful, False otherwise.
+        """
+        pass
+        
+    @abstractmethod
+    def remove_item_from_workspace(self, item_id: Any) -> bool:
+        """
+        Removes a specific item from the workspace, e.g., when it's no longer relevant
+        or has been encoded into LTM.
+
+        Args:
+            item_id (Any): Identifier for the item to be removed.
+
+        Returns:
+            bool: True if removal was successful, False otherwise.
+        """
+        pass
+
+    @abstractmethod
+    def clear_workspace(self) -> None:
+        """
+        Clears all items from the working memory workspace.
+        This might be used when switching tasks completely or resetting context.
+        """
+        pass
+
+    @abstractmethod
+    def get_cognitive_load(self) -> float:
+        """
+        Returns an estimate of the current cognitive load on Working Memory.
+        This could be based on the number of items, complexity of items,
+        processing demands, etc. Useful for the Central Executive and Self-Model.
+
+        Returns:
+            float: A value representing cognitive load (e.g., a percentage from 0.0 to 1.0).
+        """
+        pass
+
+    # Methods related to the Central Executive (conceptual, as CE is part of WM)
+
+    @abstractmethod
+    def allocate_attentional_resources(self, task_priority: Dict) -> bool:
+        """
+        Simulates the Central Executive function of allocating attention to specific
+        tasks or information streams based on priority.
+
+        Args:
+            task_priority (Dict): A dictionary specifying tasks and their priorities.
+                                  Example: {'task_A_processing': 'high', 'background_monitoring': 'low'}
+        Returns:
+            bool: True if allocation was successful/updated.
+        """
+        pass
+
+    @abstractmethod
+    def coordinate_modules(self, task_goal: str, required_modules: List[str]) -> Dict:
+        """
+        Simulates the Central Executive's role in coordinating other cognitive modules
+        to achieve a specific task goal. This is a high-level conceptual method.
+
+        Args:
+            task_goal (str): The goal to be achieved (e.g., "understand_user_query").
+            required_modules (List[str]): List of module names needed for the task.
+
+        Returns:
+            Dict: A status or result from the coordination effort.
+                  Example: {'status': 'coordination_initiated', 'task_id': 'task_123'}
+        """
+        pass
+        
+    # BaseMemoryModule methods that still need to be implemented by concrete classes
+    # store, retrieve, manage_capacity, handle_forgetting, get_status
+    # Their specific implementations for WM will differ significantly from LTM.
+    # For example, WM's `store` is more like `add_item_to_workspace`, `retrieve` like `get_workspace_contents`.
+    # `manage_capacity` is critical due to WM's limited size.
+    # `handle_forgetting` in WM might be rapid decay or displacement.
+
+if __name__ == '__main__':
+    # Conceptual illustration for WorkingMemoryModule
+
+    class ConceptualWMImpl(WorkingMemoryModule):
+        def __init__(self, capacity=5): # Small capacity for demo
+            self.workspace = [] # Holds tuples of (item, source_module, context)
+            self.capacity = capacity
+            print(f"ConceptualWMImpl initialized with capacity {self.capacity}.")
+
+        # --- BaseMemoryModule methods (simplified implementations for WM context) ---
+        def store(self, information: dict, context: dict = None) -> bool:
+            # In WM, 'store' is akin to adding an item if it's not directly from a module
+            print(f"ConceptualWMImpl (Base Store): Adding general info to workspace: {information}")
+            return self.add_item_to_workspace(information, source_module="DirectStore", context=context)
+
+        def retrieve(self, query: dict, criteria: dict = None) -> list[dict]:
+            # Base retrieve could be a generic search through workspace items
+            print(f"ConceptualWMImpl (Base Retrieve): Querying workspace with: {query}")
+            results = []
+            # Simplified search: if query has 'content_type', match item['type']
+            if 'content_type' in query:
+                for item_data in self.workspace:
+                    item = item_data[0] # actual item
+                    if isinstance(item, dict) and item.get('type') == query['content_type']:
+                        results.append(item)
+            return results
+        
+        def manage_capacity(self) -> None:
+            print(f"ConceptualWMImpl: Checking capacity. Current items: {len(self.workspace)}/{self.capacity}")
+            while len(self.workspace) > self.capacity:
+                removed_item = self.workspace.pop(0) # FIFO for simplicity
+                print(f"ConceptualWMImpl: Capacity exceeded. Removed oldest item: {removed_item[0]}")
+            print("ConceptualWMImpl: manage_capacity() done.")
+
+
+        def handle_forgetting(self, strategy: str = 'default') -> None:
+            # For WM, forgetting is often rapid decay or displacement, managed by capacity.
+            print(f"ConceptualWMImpl: handle_forgetting() called with strategy {strategy}. Typically managed by capacity.")
+            if strategy == 'clear_all':
+                self.clear_workspace()
+
+        def get_status(self) -> dict:
+            load = len(self.workspace) / self.capacity if self.capacity > 0 else 1.0
+            return {
+                'items_in_workspace': len(self.workspace),
+                'capacity': self.capacity,
+                'cognitive_load_percentage': load * 100,
+                'module_type': 'ConceptualWMImpl'
+            }
+
+        # --- WorkingMemoryModule specific methods ---
+        def add_item_to_workspace(self, item: Any, source_module: str, context: Dict = None) -> bool:
+            print(f"ConceptualWMImpl: Adding item from {source_module}: {item}")
+            if len(self.workspace) >= self.capacity:
+                self.manage_capacity() # Try to make space
+                if len(self.workspace) >= self.capacity: # Still full
+                    print("ConceptualWMImpl: Workspace full, item not added.")
+                    return False
+            self.workspace.append((item, source_module, context or {}))
+            return True
+
+        def get_workspace_contents(self, criteria: Dict = None) -> List[Any]:
+            print(f"ConceptualWMImpl: Retrieving workspace contents. Criteria: {criteria}")
+            # Simplified: returns all items for now
+            return [item_data[0] for item_data in self.workspace]
+
+        def update_item_in_workspace(self, item_id: Any, new_content: Any = None, new_context: Dict = None) -> bool:
+            print(f"ConceptualWMImpl: update_item_in_workspace - Conceptually, would find item by ID and update.")
+            # This requires a way to identify items, e.g., if items are dicts with an 'id' field.
+            # For this simple list-based workspace, this is non-trivial without more structure.
+            return False # Placeholder
+
+        def remove_item_from_workspace(self, item_id: Any) -> bool:
+            print(f"ConceptualWMImpl: remove_item_from_workspace - Conceptually, would find item by ID and remove.")
+            # Similar to update, needs item identification.
+            return False # Placeholder
+
+        def clear_workspace(self) -> None:
+            print("ConceptualWMImpl: Clearing workspace.")
+            self.workspace = []
+            
+        def get_cognitive_load(self) -> float:
+            return len(self.workspace) / self.capacity if self.capacity > 0 else 1.0
+
+        def allocate_attentional_resources(self, task_priority: Dict) -> bool:
+            print(f"ConceptualWMImpl (Central Executive): Allocating attention based on: {task_priority}")
+            # In a real system, this would influence what gets processed or attended to.
+            return True
+
+        def coordinate_modules(self, task_goal: str, required_modules: List[str]) -> Dict:
+            print(f"ConceptualWMImpl (Central Executive): Coordinating for goal '{task_goal}' using modules: {required_modules}")
+            # This would involve complex inter-module communication logic.
+            return {'status': 'coordination_conceptualized', 'task_id': task_goal}
+
+    # Conceptual usage:
+    wm_instance = ConceptualWMImpl(capacity=3)
+    wm_instance.add_item_to_workspace({'type': 'perception', 'data': 'user_said_hello'}, "PerceptionModule", {'priority': 'high'})
+    wm_instance.add_item_to_workspace({'type': 'ltm_retrieval', 'concept': 'hello_response', 'value': 'Hi there!'}, "LTMModule")
+    
+    print(f"WM Contents: {wm_instance.get_workspace_contents()}")
+    print(f"WM Cognitive Load: {wm_instance.get_cognitive_load()*100:.2f}%")
+    
+    wm_instance.add_item_to_workspace({'type': 'internal_thought', 'idea': 'consider_context'}, "SelfModel")
+    # This should trigger capacity management
+    wm_instance.add_item_to_workspace({'type': 'goal', 'goal_id': 'respond_politely'}, "MotivationalSystem") 
+    # This item might not be added if capacity is full and oldest wasn't perception.
+
+    print(f"WM Status: {wm_instance.get_status()}")
+    wm_instance.allocate_attentional_resources({'respond_politely_task': 'high'})
+    wm_instance.coordinate_modules("respond_to_user", ["LTMModule", "BehaviorGenerationModule"])
+
+```

--- a/ToDoList.md
+++ b/ToDoList.md
@@ -52,3 +52,14 @@
 - [ ] Conduct a survey and report on existing Python libraries and frameworks that could be suitable for implementing key aspects of the PiaAGI cognitive architecture (e.g., for probabilistic reasoning, knowledge representation, symbolic AI, agent simulation, multi-agent systems).
 - [ ] Begin drafting specific computational models for the **Motivational System (Section 3.3 and 4.1.6)**, focusing on how intrinsic goals (e.g., curiosity, competence) could be mathematically formulated and algorithmically implemented to drive agent behavior.
 - [ ] Design a conceptual framework for the **Architectural Maturation (Section 3.2.1)** process, detailing how specific learning experiences or developmental milestones might trigger changes in module capacities or inter-module connectivity.
+- [x] Create `PiaAGI_Hub/cognitive_module_library/` directory.
+- [x] Define Abstract Base Class `BaseMemoryModule` in `PiaAGI_Hub/cognitive_module_library/base_memory_module.py`.
+- [x] Define Interface `LongTermMemoryModule` in `PiaAGI_Hub/cognitive_module_library/long_term_memory_module.py`.
+- [x] Define Interface `WorkingMemoryModule` in `PiaAGI_Hub/cognitive_module_library/working_memory_module.py`.
+- [x] Add `README.md` to `PiaAGI_Hub/cognitive_module_library/`.
+- [ ] CML: Define Interface for `PerceptionModule` in `PiaAGI_Hub/cognitive_module_library/perception_module.py` (Ref PiaAGI.md Sections 4.1.1, 4.3).
+- [ ] CML: Define Interface for `MotivationalSystemModule` in `PiaAGI_Hub/cognitive_module_library/motivational_system_module.py` (Ref PiaAGI.md Sections 3.3, 4.1.6).
+- [ ] CML: Define Interface for `EmotionModule` in `PiaAGI_Hub/cognitive_module_library/emotion_module.py` (Ref PiaAGI.md Sections 3.4, 4.1.7).
+- [ ] CML: Define Interface for `PlanningAndDecisionMakingModule` in `PiaAGI_Hub/cognitive_module_library/planning_decision_making_module.py` (Ref PiaAGI.md Sections 4.1.8, 4.4).
+- [ ] CML: Define Interface for `SelfModelModule` in `PiaAGI_Hub/cognitive_module_library/self_model_module.py` (Ref PiaAGI.md Section 4.1.10).
+```


### PR DESCRIPTION
This commit introduces the foundational structure for the PiaAGI Cognitive Module Library (CML) and defines the first set of abstract interfaces for memory-related modules.

Changes:
- Created `PiaAGI_Hub/cognitive_module_library/` directory.
- Added `base_memory_module.py` with the `BaseMemoryModule` ABC, defining a common interface for all memory systems (store, retrieve, manage_capacity, handle_forgetting, get_status).
- Added `long_term_memory_module.py` with the `LongTermMemoryModule` ABC, inheriting from BaseMemoryModule and adding specific interfaces for semantic, episodic, and procedural LTM components.
- Added `working_memory_module.py` with the `WorkingMemoryModule` ABC, inheriting from BaseMemoryModule and adding specific interfaces for WM operations, including conceptual methods for Central Executive functions.
- Added a `README.md` in the CML directory explaining its purpose and current contents.
- Updated the main `ToDoList.md` to reflect this progress and outline next steps for CML development.

These interfaces provide a structural foundation for future implementation and integration of PiaAGI cognitive modules, aligning with the architecture described in PiaAGI.md.