### PR TITLE
feat(CML): Define core cognitive module interfaces

### DIFF
--- a/PiaAGI_Hub/cognitive_module_library/README.md
+++ b/PiaAGI_Hub/cognitive_module_library/README.md
@@ -27,17 +27,36 @@ This initial version of the CML provides abstract base classes for the following
     *   **Purpose:** Extends `BaseMemoryModule` to define the interface for Working Memory. WM is a limited-capacity system for temporarily holding and actively processing information relevant to current tasks. It also conceptually includes functions of the Central Executive (attention, coordination).
     *   **PiaAGI.md Sections:** 3.1.1 (WM details), 3.1.2 (Attention and Cognitive Control/Central Executive), 4.1.2 (Working Memory Module).
 
+4.  **[`PerceptionModule`](perception_module.py)**:
+    *   **Purpose:** Handles the processing of raw sensory input from various modalities, transforming it into a format usable by other cognitive modules.
+    *   **PiaAGI.md Sections:** 3.1.3 (Sensory Processing), 4.1.1 (Perception Module).
+
+5.  **[`MotivationalSystemModule`](motivational_system_module.py)**:
+    *   **Purpose:** Manages the agent's internal drives, needs, and goals. It is responsible for generating motivation and influencing goal selection.
+    *   **PiaAGI.md Sections:** 3.2.1 (Drives, Needs, and Goals), 4.2.1 (Motivational System).
+
+6.  **[`EmotionModule`](emotion_module.py)**:
+    *   **Purpose:** Models and processes emotions, which play a crucial role in evaluating situations, influencing decision-making, and modulating behavior and cognitive processes.
+    *   **PiaAGI.md Sections:** 3.2.2 (Emotional Processing), 4.2.2 (Emotion Module).
+
+7.  **[`PlanningAndDecisionMakingModule`](planning_and_decision_making_module.py)**:
+    *   **Purpose:** Responsible for generating possible actions, evaluating them, selecting an optimal action or sequence of actions (plan) to achieve current goals.
+    *   **PiaAGI.md Sections:** 3.1.5 (Decision Making and Action Selection), 3.1.6 (Planning and Problem Solving), 4.1.5 (Planning and Decision-Making Module).
+
+8.  **[`SelfModelModule`](self_model_module.py)**:
+    *   **Purpose:** Maintains and updates the agent's internal representation of itself, including its own states, capabilities, beliefs, and history. This contributes to self-awareness and metacognitive abilities.
+    *   **PiaAGI.md Sections:** 3.2.4 (Self-Reflection and Metacognition), 4.2.4 (Self-Model Module).
+
+## Core Module Interfaces
+
+(This section title can be considered if a more distinct separation from memory modules is desired in the future, but for now, the above list under "Current Modules" should suffice and maintain consistency.)
+
 ## Future Development
 
 The CML will be expanded to include interfaces and foundational implementations for other core PiaAGI cognitive modules, such as:
-*   Perception Module
 *   Attention Module
 *   Learning Module(s)
-*   Motivational System Module
-*   Emotion Module
-*   Planning and Decision-Making Module
 *   Behavior Generation Module
-*   Self-Model Module
 *   Theory of Mind (ToM) / Social Cognition Module
 *   Communication Module
 

--- a/PiaAGI_Hub/cognitive_module_library/emotion_module.py
+++ b/PiaAGI_Hub/cognitive_module_library/emotion_module.py
@@ -1,0 +1,43 @@
+import abc
+from typing import Dict, Any
+
+class EmotionModule(abc.ABC):
+    """
+    Abstract base class for emotion modules.
+    """
+
+    @abc.abstractmethod
+    def update_emotions(self, internal_states: Dict[str, Any], external_events: Dict[str, Any]) -> None:
+        """
+        Updates the emotional state based on internal cognitive states and external events.
+
+        Args:
+            internal_states: A dictionary representing internal cognitive states.
+            external_events: A dictionary representing external events or stimuli.
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_emotional_state(self) -> Dict[str, float]: # Assuming emotion intensities are floats
+        """
+        Returns the current emotional state.
+
+        Returns:
+            A dictionary where keys are emotion labels (e.g., "happiness", "sadness")
+            and values are their intensities (e.g., float between 0 and 1).
+        """
+        pass
+
+    @abc.abstractmethod
+    def influence_cognition(self, cognitive_processes: Any) -> Any:
+        """
+        Modifies or influences other cognitive processes based on the current emotional state.
+
+        Args:
+            cognitive_processes: The cognitive processes or components to be influenced.
+                                 This could be a specific module, a set of parameters, or data.
+
+        Returns:
+            The modified cognitive processes or the outcome of the influence.
+        """
+        pass

--- a/PiaAGI_Hub/cognitive_module_library/motivational_system_module.py
+++ b/PiaAGI_Hub/cognitive_module_library/motivational_system_module.py
@@ -1,0 +1,40 @@
+import abc
+from typing import List, Dict, Any
+
+class MotivationalSystemModule(abc.ABC):
+    """
+    Abstract base class for motivational system modules.
+    """
+
+    @abc.abstractmethod
+    def update_drives(self, new_stimuli: Dict[str, Any]) -> None:
+        """
+        Updates the internal drives or needs based on new stimuli or internal states.
+
+        Args:
+            new_stimuli: A dictionary containing new stimuli or internal state changes.
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_goals(self) -> List[Any]: # Assuming goals can be complex objects, not just strings
+        """
+        Returns a list of current goals, potentially prioritized.
+
+        Returns:
+            A list of current goals.
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_motivation_level(self, goal_id: str) -> float:
+        """
+        Returns the motivation level for a specific goal.
+
+        Args:
+            goal_id: The identifier of the goal.
+
+        Returns:
+            The motivation level (e.g., a float between 0 and 1).
+        """
+        pass

--- a/PiaAGI_Hub/cognitive_module_library/perception_module.py
+++ b/PiaAGI_Hub/cognitive_module_library/perception_module.py
@@ -1,0 +1,30 @@
+import abc
+from typing import Any
+
+class PerceptionModule(abc.ABC):
+    """
+    Abstract base class for perception modules.
+    """
+
+    @abc.abstractmethod
+    def perceive(self, sensory_data: dict) -> None:
+        """
+        Processes raw sensory input.
+
+        Args:
+            sensory_data: A dictionary containing raw sensory data.
+        """
+        pass
+
+    @abc.abstractmethod
+    def process_sensory_input(self, processed_data: dict) -> Any:
+        """
+        Further processes or interprets the perceived data.
+
+        Args:
+            processed_data: A dictionary containing processed sensory data.
+
+        Returns:
+            Any: The result of the processing, can be any type.
+        """
+        pass

--- a/PiaAGI_Hub/cognitive_module_library/planning_and_decision_making_module.py
+++ b/PiaAGI_Hub/cognitive_module_library/planning_and_decision_making_module.py
@@ -1,0 +1,63 @@
+import abc
+from typing import List, Dict, Any
+
+class PlanningAndDecisionMakingModule(abc.ABC):
+    """
+    Abstract base class for planning and decision-making modules.
+    """
+
+    @abc.abstractmethod
+    def generate_possible_actions(self, current_state: Any, goals: List[Any]) -> List[Any]:
+        """
+        Generates a list of possible actions based on the current state and goals.
+
+        Args:
+            current_state: The current state of the agent or environment.
+            goals: A list of current goals.
+
+        Returns:
+            A list of possible actions.
+        """
+        pass
+
+    @abc.abstractmethod
+    def evaluate_actions(self, actions: List[Any], current_state: Any, goals: List[Any]) -> Dict[Any, float]: # Action to score
+        """
+        Evaluates the generated actions, returning a score or preference for each.
+
+        Args:
+            actions: A list of actions to evaluate.
+            current_state: The current state of the agent or environment.
+            goals: A list of current goals.
+
+        Returns:
+            A dictionary mapping each action to its evaluation score or preference.
+        """
+        pass
+
+    @abc.abstractmethod
+    def select_action(self, evaluated_actions: Dict[Any, float]) -> Any:
+        """
+        Selects the best action to take based on their evaluation.
+
+        Args:
+            evaluated_actions: A dictionary of actions and their evaluations.
+
+        Returns:
+            The selected action.
+        """
+        pass
+
+    @abc.abstractmethod
+    def create_plan(self, goal: Any, current_state: Any) -> List[Any]:
+        """
+        Creates a sequence of actions (a plan) to achieve a given goal.
+
+        Args:
+            goal: The goal to achieve.
+            current_state: The current state of the agent or environment.
+
+        Returns:
+            A list of actions representing the plan.
+        """
+        pass

--- a/PiaAGI_Hub/cognitive_module_library/self_model_module.py
+++ b/PiaAGI_Hub/cognitive_module_library/self_model_module.py
@@ -1,0 +1,55 @@
+import abc
+from typing import Dict, Any, List # Added List for experiences if it's a list of events
+
+class SelfModelModule(abc.ABC):
+    """
+    Abstract base class for self-model modules.
+    """
+
+    @abc.abstractmethod
+    def update_self_representation(self, experiences: Any, internal_states: Dict[str, Any]) -> None:
+        """
+        Updates the agent's internal model of itself based on new experiences and states.
+
+        Args:
+            experiences: New experiences, which could be a single event, a list of events,
+                         or structured data representing learning episodes.
+            internal_states: A dictionary representing the agent's current internal states
+                             (e.g., emotional state, cognitive load).
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_self_representation(self) -> Dict[str, Any]:
+        """
+        Returns the current self-model.
+
+        Returns:
+            A dictionary representing the agent's beliefs about its capabilities,
+            traits, current states, etc.
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_self_awareness_level(self) -> float:
+        """
+        Returns a measure of the agent's current level of self-awareness.
+
+        Returns:
+            A float representing the level of self-awareness (e.g., between 0 and 1).
+        """
+        pass
+
+    @abc.abstractmethod
+    def predict_own_performance(self, task: Any) -> Any:
+        """
+        Predicts the agent's own performance or outcome on a given task.
+
+        Args:
+            task: A representation of the task for which performance is to be predicted.
+
+        Returns:
+            A prediction of performance, which could be a score, a probability of success,
+            or expected outcome.
+        """
+        pass

--- a/ToDoList.md
+++ b/ToDoList.md
@@ -57,9 +57,9 @@
 - [x] Define Interface `LongTermMemoryModule` in `PiaAGI_Hub/cognitive_module_library/long_term_memory_module.py`.
 - [x] Define Interface `WorkingMemoryModule` in `PiaAGI_Hub/cognitive_module_library/working_memory_module.py`.
 - [x] Add `README.md` to `PiaAGI_Hub/cognitive_module_library/`.
-- [ ] CML: Define Interface for `PerceptionModule` in `PiaAGI_Hub/cognitive_module_library/perception_module.py` (Ref PiaAGI.md Sections 4.1.1, 4.3).
-- [ ] CML: Define Interface for `MotivationalSystemModule` in `PiaAGI_Hub/cognitive_module_library/motivational_system_module.py` (Ref PiaAGI.md Sections 3.3, 4.1.6).
-- [ ] CML: Define Interface for `EmotionModule` in `PiaAGI_Hub/cognitive_module_library/emotion_module.py` (Ref PiaAGI.md Sections 3.4, 4.1.7).
-- [ ] CML: Define Interface for `PlanningAndDecisionMakingModule` in `PiaAGI_Hub/cognitive_module_library/planning_decision_making_module.py` (Ref PiaAGI.md Sections 4.1.8, 4.4).
-- [ ] CML: Define Interface for `SelfModelModule` in `PiaAGI_Hub/cognitive_module_library/self_model_module.py` (Ref PiaAGI.md Section 4.1.10).
+- [x] CML: Define Interface for `PerceptionModule` in `PiaAGI_Hub/cognitive_module_library/perception_module.py` (Ref PiaAGI.md Sections 4.1.1, 4.3).
+- [x] CML: Define Interface for `MotivationalSystemModule` in `PiaAGI_Hub/cognitive_module_library/motivational_system_module.py` (Ref PiaAGI.md Sections 3.3, 4.1.6).
+- [x] CML: Define Interface for `EmotionModule` in `PiaAGI_Hub/cognitive_module_library/emotion_module.py` (Ref PiaAGI.md Sections 3.4, 4.1.7).
+- [x] CML: Define Interface for `PlanningAndDecisionMakingModule` in `PiaAGI_Hub/cognitive_module_library/planning_and_decision_making_module.py` (Ref PiaAGI.md Sections 4.1.8, 4.4).
+- [x] CML: Define Interface for `SelfModelModule` in `PiaAGI_Hub/cognitive_module_library/self_model_module.py` (Ref PiaAGI.md Section 4.1.10).
 ```


### PR DESCRIPTION
Adds abstract base classes for the following cognitive modules within the PiaAGI Cognitive Module Library (PiaCML):

- PerceptionModule: For processing sensory input.
- MotivationalSystemModule: For managing drives, needs, and goals.
- EmotionModule: For modeling and processing emotions.
- PlanningAndDecisionMakingModule: For action selection and planning.
- SelfModelModule: For maintaining my self-representation.

Updates the CML README to include these new interfaces and reflects their completion in the project ToDoList.md.