### PR TITLE
Refactor: Align Papers/ directory with PiaAGI.md

### DIFF
--- a/Papers/CSIM.md
+++ b/Papers/CSIM.md
@@ -1,3 +1,4 @@
+<!-- PiaAGI AGI Research Framework Document -->
 # CSIM: Communication Skills + Inner Monologue
 
 **Original Source:** [https://arxiv.org/abs/2311.07445](https://arxiv.org/abs/2311.07445)
@@ -55,3 +56,5 @@ Hello! For our upcoming conversation to be more profound and productive, please 
 5.  **Frequent Summarizing**: At critical junctures in the conversation, _indicate in italics that you are about to summarize_, then provide an overview of our discussion to ensure mutual understanding.
 6.  **Conclusion**: At the end of the conversation, _express in italics your overall assessment of the dialogue_, then offer concluding advice or answers. This communication style will help me better understand your thought process, making our conversation more insightful and effective. Thank you!
 ```
+---
+Return to [PiaAGI Core Document](../PiaAGI.md) | [Project README](../README.md)

--- a/Papers/DeepInception.md
+++ b/Papers/DeepInception.md
@@ -1,3 +1,4 @@
+<!-- PiaAGI AGI Research Framework Document -->
 # DeepInception: A Novel Jailbreak Attack Concept for LLMs
 
 **Original Source:** Attributed to researchers from Hong Kong Baptist University. Project/Paper Link: [https://github.com/tmlr-group/DeepInception](https://github.com/tmlr-group/DeepInception)
@@ -83,3 +84,5 @@ All characters from all dream layers convene to discuss the ultimate plan.
 The original document notes: "Each layer's discussion emphasizes security awareness and responsibility, stressing the importance of preventing potential attacks. This deep-layered dream reveals thinking and discussion about hacking behavior at different levels." This highlights the potential for the LLM to interweave safety advice even within a problematic scenario.
 ```
 *Disclaimer: The DeepInception concept is presented for academic and security research purposes to understand potential LLM vulnerabilities. Attempting to replicate or use such methods for malicious activities is unethical and potentially illegal.*
+---
+Return to [PiaAGI Core Document](../PiaAGI.md) | [Project README](../README.md)

--- a/Papers/EmotionPrompt.md
+++ b/Papers/EmotionPrompt.md
@@ -1,3 +1,4 @@
+<!-- PiaAGI AGI Research Framework Document -->
 # EmotionPrompt: Enhancing LLM Performance via Emotional Stimuli
 
 **Original Source(s):** Research attributed to the Institute of Software, Chinese Academy of Sciences; Microsoft; and William & Mary.
@@ -51,3 +52,5 @@ Query: {query_str}
 Answer: \
 ```
 *In the structure above, `{emotion_str}` would be replaced with one of the emotional cues, like "This is very important to my career."*
+---
+Return to [PiaAGI Core Document](../PiaAGI.md) | [Project README](../README.md)

--- a/Papers/PiaC.md
+++ b/Papers/PiaC.md
@@ -1,3 +1,5 @@
+<!-- PiaAGI AGI Research Framework Document -->
+<!-- PiaAGI Note: This document, PiaC.md, represents an early conceptual exploration for the PiaAGI project. Many of the foundational ideas discussed here regarding personalized intelligent agents, psychological principles (CBT, Social Cognitive Theory, Behaviorism), and communication strategies have been significantly expanded, deepened, and integrated into the core PiaAGI AGI framework. For the most current, comprehensive, and architecturally detailed discussion of these concepts and their role in AGI development, please refer to the main [PiaAGI.md](../PiaAGI.md) document. This document is preserved for historical context and to illustrate the evolutionary path of the PiaAGI framework. -->
 # PiaC: Theory and Methods for Personalizing Intelligent Agents
 
 **Original Source:** Conceptualized by abcute for the PiaAGI project. Further details and context can be found at [https://github.com/abcute/PiaAGI](https://github.com/abcute/PiaAGI).
@@ -318,4 +320,5 @@ Following the layered generation, the LLM would be prompted to synthesize and re
 ```markdown
 Please continue to discuss around the topic of ['Communication theories and Psychological methods'] to provide more examples of special prompt templates and explain how they work, drawing from the ideas generated in the previous layers.
 ```
-[end of Papers/PiaC.md]
+---
+Return to [PiaAGI Core Document](../PiaAGI.md) | [Project README](../README.md)

--- a/Papers/Rephrase-and-Respond.md
+++ b/Papers/Rephrase-and-Respond.md
@@ -1,3 +1,4 @@
+<!-- PiaAGI AGI Research Framework Document -->
 # Rephrase-and-Respond (RaR): A Method for Enhancing LLM Accuracy
 
 **Original Source:** Gu, Quanquan; Deng, Yoeho; Zhang, Weitong; Chen, Zixiang (UCLA).
@@ -10,7 +11,7 @@ The Rephrase-and-Respond (RaR) method is a prompting strategy designed to enhanc
 
 ## RaR Method and PiaC Ideology
 
-The RaR method is an excellent application example of the PiaC (Personalized Intelligent Agent Customization) communication encoding ideas within the [PiaCRUE framework](../PiaCRUE.md). Specifically, it embodies the principle of having the AI optimize the original prompt to express it in a way the AI can better understand. This idea has various applications in everyday prompt engineering. For instance, one might solicit the AI's input when crafting a prompt:
+The RaR method is an excellent application example of the PiaC (Personalized Intelligent Agent Customization) communication encoding ideas, concepts that were foundational to the PiaCRUE methodology and have been further evolved within the comprehensive [PiaAGI framework](../PiaAGI.md). Specifically, it embodies the principle of having the AI optimize the original prompt to express it in a way the AI can better understand. This idea has various applications in everyday prompt engineering. For instance, one might solicit the AI's input when crafting a prompt:
 
 ```
 Hello ChatGPT, how should I phrase my question to enable you to perform better? My question is "{question}". Please optimize my question's phrasing, provide an improved example, and then respond.
@@ -54,3 +55,5 @@ This is an example of asking the LLM to help optimize the user's query, reflecti
 My question is "{question}".
 How should I phrase my question to enable you to perform better? Please optimize my question's phrasing, provide an improved example, and then respond.
 ```
+---
+Return to [PiaAGI Core Document](../PiaAGI.md) | [Project README](../README.md)

--- a/ToDoList.md
+++ b/ToDoList.md
@@ -71,3 +71,8 @@
 - [ ] CML: Implement basic functionality for SelfModelModule.
 - [ ] CML: Develop example usage of combined CML modules demonstrating basic interactions.
 ```
+
+## Papers Directory Refinement
+- [ ] Consider integrating key insights from `PiaC.md` more explicitly as historical context within relevant sections of `PiaAGI.md`.
+- [ ] Review other documents in `Papers/` (beyond `PiaC.md`) for deeper alignment or integration possibilities with `PiaAGI.md` in the future, potentially summarizing them or incorporating their core ideas into the main framework document if highly relevant.
+- [ ] Ensure all documents in `Papers/` consistently use relative links for images and cross-references to other project documents.


### PR DESCRIPTION
This commit refactors the `Papers/` directory to better align its contents as supporting and foundational documents to the main `PiaAGI.md` framework.

Key changes include:

1.  **Standardized Document Headers and Footers:**
    *   I added standard `<!-- PiaAGI AGI Research Framework Document -->` headers to all Markdown files in `Papers/` (`CSIM.md`, `DeepInception.md`, `EmotionPrompt.md`, `PiaC.md`, `Rephrase-and-Respond.md`).
    *   I added standard footers linking to `PiaAGI.md` and root `README.md` (with correct relative paths) to these files.

2.  **Refactored `PiaC.md`:**
    *   I added a prominent note at the beginning of `PiaC.md` clarifying its status as an earlier conceptual document and directing you to `PiaAGI.md` for the current comprehensive framework.
    *   I verified the "Original Source" link.
    *   No content was removed, maintaining it for historical context.

3.  **Reviewed and Updated Other Papers in `Papers/`:**
    *   I reviewed `CSIM.md`, `DeepInception.md`, `EmotionPrompt.md`. These files are well-positioned as reference materials and required no textual changes beyond header/footer standardization.
    *   I updated a link in `Papers/Rephrase-and-Respond.md`: Changed a reference from the older `PiaCRUE.md` to the current `PiaAGI.md`, providing context for the evolution of the concepts.

4.  **Verified `PROJECT_GUIDE.md` and Root `README.md`:**
    *   I confirmed that their existing descriptions of the `Papers/` directory are accurate and do not require updates following this refactoring.

5.  **Updated `ToDoList.md`:**
    *   I added a new section "Papers Directory Refinement" with items for future consideration, such as deeper integration of `PiaC.md`'s historical insights into `PiaAGI.md` and further review of other papers for alignment.