### PR TITLE
Docs: Add README.md for Papers/ directory and update PROJECT_GUIDE.md

### DIFF
--- a/PROJECT_GUIDE.md
+++ b/PROJECT_GUIDE.md
@@ -36,7 +36,7 @@ To help you quickly find the information you need, here is a description of the 
         *   `USAGE.md`: Instructions and examples for using the `prompt_engine_mvp.py`.
     *   The main `README.md` in this directory provides an overview of these tools. Researchers and developers interested in practical implementations and experimentation should focus here.
 
-*   **`Papers/`**: This directory houses theoretical research papers, conceptual explorations, and in-depth analyses related to the PiaAGI framework and its AGI aspirations. These documents provide academic context and deeper insights into the methodologies.
+*   **`Papers/`**: This directory ([see its `README.md`](Papers/README.md) for a summary of contents) houses theoretical research papers, conceptual explorations, and in-depth analyses related to the PiaAGI framework and its AGI aspirations. These documents provide academic context and deeper insights into the methodologies.
     *   Key papers discuss the application of communication theories, psychological models, and ethical considerations relevant to building AGI.
 
 *   **`Examples/`**: This directory contains various practical examples related to PiaAGI principles and foundational R-U-E prompting. The primary, fully documented foundational examples ('Viral Xiaohongshu Post Copywriting Expert,' 'PoetActor' examples) have been moved to **Appendix A of `PiaAGI.md`**. AGI-specific examples are detailed within the main body of `PiaAGI.md` (Section 7). The `Examples/` directory may still contain other illustrative scenarios or simpler templates like `PiaCRUE_Template.md` and `PiaCRUE_mini.md`.

--- a/Papers/README.md
+++ b/Papers/README.md
@@ -1,0 +1,24 @@
+<!-- PiaAGI AGI Research Framework Document -->
+# Papers and Conceptual Explorations
+
+This directory contains a collection of theoretical research papers, summaries of external research, conceptual explorations, and foundational documents that are relevant to the PiaAGI framework. These papers provide academic context, explore underlying theories, or represent earlier ideas that have contributed to the development of the comprehensive [PiaAGI AGI Research Framework](../PiaAGI.md).
+
+## Documents
+
+*   **[PiaC.md](PiaC.md):**
+    *   Outlines "PiaC" (Personalizing Intelligent Agent Customization), an early conceptual exploration within the PiaAGI project. It proposes methodologies for customizing Large Language Models (LLMs) into domain-specific Personalized Intelligent Agents (Pia) by applying principles from psychology (Cognitive Behavioral Therapy, Social Cognitive Theory, Behaviorism) and structured communication. Key ideas from this document have been expanded and integrated into the main `PiaAGI.md`.
+
+*   **[CSIM.md](CSIM.md):**
+    *   Summarizes the CSIM (Communication Skills + Inner Monologue) framework, an approach designed to enhance the human-like qualities and proactivity of LLMs by introducing an "inner monologue" process to apply specific communication skills.
+
+*   **[DeepInception.md](DeepInception.md):**
+    *   Summarizes the "DeepInception" jailbreak attack concept, which explores leveraging personalization and "self-delusion" psychological characteristics of LLMs through layered scenarios to potentially bypass safety mechanisms. It offers insights into psychological and narrative interaction approaches.
+
+*   **[EmotionPrompt.md](EmotionPrompt.md):**
+    *   Discusses the "EmotionPrompt" concept, investigating how incorporating emotional stimuli into prompts can influence the performance (e.g., truthfulness, informativeness) of Large Language Models.
+
+*   **[Rephrase-and-Respond.md](Rephrase-and-Respond.md):**
+    *   Summarizes the Rephrase-and-Respond (RaR) prompting strategy, designed to improve LLM accuracy by having the model first rephrase and expand upon a user's question before answering.
+
+---
+Return to [PiaAGI Core Document](../PiaAGI.md) | [Project README](../README.md)


### PR DESCRIPTION
This commit introduces a `README.md` file for the `Papers/` directory. This new README provides an overview of the directory's purpose and a brief summary of each paper it contains, improving navigability and context for these supporting documents.

Additionally, `PROJECT_GUIDE.md` has been updated to include a direct link to this new `Papers/README.md` in its description of the `Papers/` directory.