### PR TITLE
Docs: Add summary of Alita agent paper (arXiv:2505.20286) to Papers/

### DIFF
--- a/Papers/Alita_Agent.md
+++ b/Papers/Alita_Agent.md
@@ -1,0 +1,56 @@
+<!-- PiaAGI AGI Research Framework Document -->
+# Alita: Scalable Agentic Reasoning with Minimal Predefinition and Maximal Self-Evolution
+
+**Source:** Qiu, Jiahao, et al. "Alita: Generalist Agent Enabling Scalable Agentic Reasoning with Minimal Predefinition and Maximal Self-Evolution." arXiv preprint arXiv:2505.20286 (2025).
+**GitHub:** [https://github.com/CharlesQ9/Alita](https://github.com/CharlesQ9/Alita)
+*Note: This document summarizes the Alita agent framework, which emphasizes dynamic capability generation and self-evolution, achieving notable performance on benchmarks like GAIA.*
+
+## Abstract
+The Alita agent framework proposes a design philosophy for general AI assistants centered on "Minimal Predefinition" and "Maximal Self-Evolution." Instead of relying on extensive, manually predefined tools and workflows, Alita starts with minimal core capabilities (e.g., a web agent) and autonomously creates, refines, and reuses external capabilities as needed. This is primarily achieved through the dynamic generation, adaptation, and reuse of Model Context Protocols (MCPs)—standardized ways for systems to provide context to LLMs—tailored to specific task demands. Alita's approach aims to overcome limitations of scalability, adaptability, and generalization found in agents dependent on large sets of predefined tools.
+
+## Summary of Core Concepts
+
+Alita challenges the prevailing trend of increasing complexity in general-purpose agent design by focusing on simplicity and autonomous evolution:
+
+1.  **Minimal Predefinition:**
+    *   The agent is equipped with only a minimal set of core capabilities (e.g., a single core web agent functionality).
+    *   Avoids manually engineered components, tools, or workflows for specific tasks or modalities.
+
+2.  **Maximal Self-Evolution:**
+    *   Empowers the agent to autonomously discover, create, refine, and reuse capabilities dynamically as required by the task.
+    *   This reduces the reliance on human developers to foresee and pre-build all necessary tools.
+
+3.  **Model Context Protocols (MCPs):**
+    *   Alita dynamically generates, adapts, and reuses MCPs. MCPs are an open protocol standardizing how different systems provide context to LLMs.
+    *   Instead of static, predefined tools, Alita constructs MCPs "on-the-fly" based on task demands.
+    *   **Benefits over traditional tool creation:**
+        *   **Better Reusability:** MCPs can be saved and reused by Alita or even other, potentially weaker, agents.
+        *   **Easier Environment Management:** Standardized protocol simplifies integration.
+        *   **Agent Distillation:** The reuse of auto-generated MCPs by other agents (e.g., weaker LLMs or agents with smaller LLMs) acts as a form of knowledge distillation, improving their performance. Alita effectively "teaches" by designing useful MCPs through its own trial and error.
+        *   **Performance Enhancement:** An "MCP Box" (a collection of Alita-generated MCPs) can be connected back to Alita, helping its pass@1 performance approach its pass@N performance.
+
+4.  **Web Agent as a Core Capability:**
+    *   Alita's initial implementation heavily relies on a web agent for interacting with the external world and gathering information, which it then uses to generate MCPs.
+    *   Performance on benchmarks like GAIA is sensitive to the sophistication of the web browsing ability.
+
+5.  **Key Findings and Observations:**
+    *   Alita demonstrated strong performance on the GAIA benchmark, outperforming other notable systems.
+    *   The ability to dynamically create MCPs significantly boosted performance compared to versions without this component.
+    *   The paper highlights the potential for agents to exhibit creativity beyond human developers' initial designs.
+    *   Challenges include the gap between validation and test datasets (due to differing emphasis on web browsing vs. tool use) and the trade-offs in MCP abstraction (too high leads to overlap/overload, too low leads to overfitting).
+
+## Implications for PiaAGI
+
+The Alita framework and its concepts offer valuable insights for the PiaAGI project:
+
+*   **Tool Creation and Use (PiaAGI.md Section 3.6, 4.1.5, 4.1.8):** Alita's dynamic MCP generation strongly resonates with PiaAGI's emphasis on AGI agents being able to create and adapt tools. MCPs can be seen as a specific, powerful instantiation of self-generated tools or "cognitive tools."
+*   **Self-Model and Self-Evolution (PiaAGI.md Section 4.1.10):** Alita's "Maximal Self-Evolution" principle aligns with the PiaAGI Self-Model's role in guiding self-improvement and adaptation. The creation and refinement of an "MCP Box" can be seen as the Self-Model learning and curating a library of effective, self-generated capabilities.
+*   **Developmental Stages (PiaAGI.md Section 3.2.1):** The progression from minimal predefinition to complex, self-generated capabilities via MCPs could map to PiaAGI's developmental stages, where later stages (e.g., PiaArbor, PiaGrove) exhibit more profound self-evolution and tool innovation.
+*   **Learning Modules (PiaAGI.md Section 4.1.5):** The trial-and-error process by which Alita designs useful MCPs is a form of learning. PiaAGI's Learning Modules would be responsible for the mechanisms of creating, testing, and refining such MCP-like structures.
+*   **Architectural Simplicity and Emergence:** Alita's philosophy of "simplicity is the ultimate sophistication" and focusing on modules that "enable and stimulate creativity and evolution" is compatible with PiaAGI's aim for emergent intelligence from interacting core modules, rather than pre-programming every specific behavior.
+*   **Addressing Tool Overload:** The concept of "MCP Overload" mentioned in the Alita discussion is a relevant consideration for PiaAGI as it develops its own tool/capability management within the Self-Model and Procedural LTM.
+
+The Alita paper provides a compelling example of how an agent with minimal initial setup can achieve sophisticated reasoning and problem-solving through dynamic capability generation, offering a promising direction for developing scalable and adaptive AGI systems like PiaAGI.
+
+---
+Return to [PiaAGI Core Document](../PiaAGI.md) | [Project README](../README.md)

--- a/Papers/README.md
+++ b/Papers/README.md
@@ -14,6 +14,9 @@ This directory contains a collection of theoretical research papers, summaries o
 *   **[AI_Narrative_Understanding.md](AI_Narrative_Understanding.md):** (Hypothetical)
     *   Proposes a framework on the role of narrative and storytelling in enhancing human-AI understanding, examining how AI (especially LLMs) might develop deeper contextual awareness and worldviews through narrative processing.
 
+*   **[Alita_Agent.md](Alita_Agent.md):**
+    *   Summarizes the Alita agent framework (arXiv:2505.20286), which emphasizes "Minimal Predefinition" and "Maximal Self-Evolution" through dynamic generation and reuse of Model Context Protocols (MCPs) for scalable agentic reasoning.
+
 *   **[CSIM.md](CSIM.md):**
     *   Summarizes the CSIM (Communication Skills + Inner Monologue) framework, an approach designed to enhance the human-like qualities and proactivity of LLMs by introducing an "inner monologue" process to apply specific communication skills.
 

--- a/ToDoList.md
+++ b/ToDoList.md
@@ -77,3 +77,4 @@
 - [ ] Review other documents in `Papers/` (beyond `PiaC.md`) for deeper alignment or integration possibilities with `PiaAGI.md` in the future, potentially summarizing them or incorporating their core ideas into the main framework document if highly relevant.
 - [ ] Ensure all documents in `Papers/` consistently use relative links for images and cross-references to other project documents.
 - [ ] Research and replace hypothetical paper summaries (`AI_Cultural_Evolution.md`, `AI_Narrative_Understanding.md`, `AI_Ethical_Heuristics.md`) with summaries of actual recent (2021-2024) relevant academic papers.
+- [ ] Explore and detail the potential integration of Alita agent's Model Context Protocol (MCP) concepts (from `Papers/Alita_Agent.md`) into PiaAGI's tool creation (Section 3.6), Self-Model (Section 4.1.10), and Learning Module (Section 4.1.5) functionalities.


### PR DESCRIPTION
This commit introduces a summary of the Alita agent paper ("Alita: Generalist Agent Enabling Scalable Agentic Reasoning with Minimal Predefinition and Maximal Self-Evolution") into the `Papers/` directory as `Alita_Agent.md`.

The summary covers Alita's core principles, such as Minimal Predefinition, Maximal Self-Evolution, and the use of Model Context Protocols (MCPs), and discusses its implications for the PiaAGI framework.

Additionally:
- `Papers/README.md` has been updated to include this new paper summary.
- `ToDoList.md` has been updated with an item to explore the integration of Alita's MCP concepts into PiaAGI.