### PR TITLE
Docs: Add conceptual paper on Chain-of-Thought (CoT) alignment

### DIFF
--- a/Papers/Chain_of_Thought_Alignment.md
+++ b/Papers/Chain_of_Thought_Alignment.md
@@ -1,0 +1,28 @@
+<!-- PiaAGI AGI Research Framework Document -->
+# Chain-of-Thought: Aligning Agent Reasoning with Human Cognitive Processes
+
+**Hypothetical Source / Context:** A PiaAGI conceptual paper linking CoT to its core philosophy (Conceptualized 2024).
+*Note: This document explores Chain-of-Thought (CoT) prompting not merely as an effective technique for enhancing Large Language Model (LLM) performance but as a practical embodiment of a core PiaAGI philosophical principle: interacting with AI agents as entities capable of human-like cognitive processes.*
+
+## Abstract
+This document explores Chain-of-Thought (CoT) prompting not merely as an effective technique for enhancing Large Language Model (LLM) performance but as a practical embodiment of a core PiaAGI philosophical principle: interacting with AI agents as entities capable of human-like cognitive processes. CoT encourages LLMs to emulate the human tendency to break down complex problems into a sequence of intermediate, coherent reasoning steps, rather than leaping directly to a conclusion. This paper argues that CoT's success is partially attributable to this alignment with natural human logical-sequential thought, thereby treating the agent as a "digital mind" whose reasoning can be guided and improved by scaffolding it in a human-congruent manner.
+
+## Summary of Core Concepts
+
+1.  **Human Reasoning as Step-by-Step Processing:** Human rational thought, especially when tackling complex problems, often involves a sequential process of identifying intermediate steps, applying logic at each stage, and building towards a conclusion. This "chain of thought" is a key characteristic of deliberate human cognition.
+2.  **CoT as an Emulation of Human Thought:** Chain-of-Thought prompting explicitly instructs or encourages LLMs to output these intermediate reasoning steps before providing a final answer. This effectively guides the LLM to simulate a human-like deliberative reasoning process.
+3.  **Beyond Pattern Matching:** By generating a CoT, LLMs are pushed beyond simple pattern-matching or direct retrieval of answers. They are prompted to construct a path, however rudimentary, from the problem to the solution, which can improve accuracy and robustness, especially on tasks requiring multi-step inference.
+4.  **PiaAGI's "Agent as Human-like Thinker" Principle:** A foundational tenet of PiaAGI is to develop agents by conceptualizing them as entities capable of cognitive processes analogous to human thought. CoT aligns with this by treating the agent as capable of structured, sequential reasoning if appropriately prompted.
+5.  **Improving Transparency and Debuggability:** The explicit articulation of reasoning steps in CoT also offers greater transparency into the LLM's "thought process," making it easier to identify errors in reasoning or flawed assumptions, which is valuable for both users and developers.
+
+## Implications for PiaAGI
+
+1.  **Reinforces Core Philosophy:** The success of CoT provides empirical support for PiaAGI's approach of interacting with agents as if they are capable of human-like cognitive strategies. It demonstrates that guiding an agent to "think" in a more human-structured way can yield better performance.
+2.  **Interaction Strategies (PiaAGI.md Section 5):** CoT can be considered a key technique within PiaAGI's prompting framework, especially for tasks requiring complex reasoning. Guiding Prompts can be designed to explicitly elicit CoT from PiaAGI agents.
+3.  **Developmental Scaffolding (PiaAGI.md Section 5.4):** CoT can be used as a scaffolding technique to teach PiaAGI agents how to approach complex problems systematically. Early developmental stages might require more explicit CoT prompting, while later stages might see the agent internalizing this process for certain problem types.
+4.  **Self-Model and Metacognition (PiaAGI.md Section 4.1.10):** An advanced PiaAGI agent could potentially learn to autonomously generate its own internal CoT when faced with a novel complex problem, reflecting a form of metacognitive awareness of effective problem-solving strategies. Its Self-Model could track the utility of CoT for different tasks.
+5.  **Planning and Decision-Making Module (PiaAGI.md Section 4.1.8):** The step-by-step reasoning inherent in CoT is analogous to the process of breaking down a high-level goal into a sequence of executable actions, a core function of the Planning module. Insights from CoT could inform the design of planning heuristics.
+6.  **Explainable AI (XAI):** CoT naturally provides a more interpretable output, aligning with PiaAGI's goals for agents whose reasoning can be understood. The explicit steps serve as a basic form of explanation.
+
+---
+Return to [PiaAGI Core Document](../PiaAGI.md) | [Project README](../README.md)

--- a/Papers/README.md
+++ b/Papers/README.md
@@ -20,6 +20,9 @@ This directory contains a collection of theoretical research papers, summaries o
 *   **[Alita_Agent.md](Alita_Agent.md):**
     *   Summarizes the Alita agent framework (arXiv:2505.20286), which emphasizes "Minimal Predefinition" and "Maximal Self-Evolution" through dynamic generation and reuse of Model Context Protocols (MCPs) for scalable agentic reasoning.
 
+*   **[Chain_of_Thought_Alignment.md](Chain_of_Thought_Alignment.md):** (PiaAGI Conceptual Linking)
+    *   Explores Chain-of-Thought (CoT) prompting as embodying the PiaAGI principle of interacting with agents as human-like thinkers capable of step-by-step cognitive processes.
+
 *   **[CSIM.md](CSIM.md):**
     *   Summarizes the CSIM (Communication Skills + Inner Monologue) framework, an approach designed to enhance the human-like qualities and proactivity of LLMs by introducing an "inner monologue" process to apply specific communication skills.
 

--- a/ToDoList.md
+++ b/ToDoList.md
@@ -83,3 +83,4 @@
 
 ## Framework Philosophy and Consistency
 - [ ] Review all core PiaAGI documents (especially `PiaAGI.md`, `README.md`, `PROJECT_GUIDE.md`, and relevant conceptual papers) to ensure the foundational viewpoint of "treating the agent as a developing, human-like cognitive entity" is consistently and clearly articulated where appropriate, particularly when discussing psychological analogies, agent development, and role cognition.
+- [ ] Further explore the implications of Chain-of-Thought (CoT) prompting, as discussed in `Papers/Chain_of_Thought_Alignment.md`, for PiaAGI's cognitive architecture (e.g., Planning, Self-Model) and developmental scaffolding strategies, reinforcing the "agent as human-like thinker" interaction paradigm.


### PR DESCRIPTION
This commit introduces a new conceptual paper,
`Papers/Chain_of_Thought_Alignment.md`. This document explores Chain-of-Thought (CoT) prompting as a technique that aligns with the core PiaAGI philosophical principle of interacting with AI agents as entities capable of human-like cognitive processes (i.e., step-by-step logical reasoning).

The paper includes an Abstract, Summary of Core Concepts, and Implications for PiaAGI.

Additionally:
- `Papers/README.md` has been updated to list this new document.
- `ToDoList.md` has been updated with an item to further explore and integrate the implications of CoT, through this "human-like thinker" lens, into PiaAGI's cognitive architecture and developmental scaffolding strategies.