### PR TITLE
I've added some foundational examples to the `Examples/Foundational_A…

### DIFF
--- a/Examples/Foundational_And_Refactored/CoT_Prompting_PiaAGI_Style.md
+++ b/Examples/Foundational_And_Refactored/CoT_Prompting_PiaAGI_Style.md
@@ -1,0 +1,84 @@
+**PiaAGI Foundational Example: Chain-of-Thought (CoT) Prompting for Enhanced Reasoning**
+
+**Use Case**: Demonstrating how to guide an agent to use a step-by-step reasoning process (Chain-of-Thought) to solve a simple problem. This aligns with PiaAGI's philosophy of emulating human-like cognitive strategies and enhancing transparency.
+
+**PiaAGI Concepts Illustrated**:
+-   **Chain-of-Thought (CoT) Prompting**: Guiding the agent to articulate its reasoning steps.
+-   **Emulating Human Cognitive Processes (PiaAGI.md Section 2.3, Papers/Chain_of_Thought_Alignment.md)**: Encouraging a structured, sequential thought process.
+-   **Transparency in Reasoning**: Making the agent's problem-solving path visible.
+-   **Planning and Decision-Making Module (PiaAGI.md Section 4.1.8)**: CoT can be seen as an externalization of this module's process.
+-   **Self-Model (PiaAGI.md Section 4.1.10)**: An advanced agent might learn to use CoT autonomously as a metacognitive strategy.
+
+**Expected Outcome**: The agent provides a step-by-step derivation of the answer to a simple multi-step problem, making its reasoning process transparent and easier to follow or debug.
+
+**Token Consumption Level**: Medium (as it requires generating intermediate steps).
+
+---
+
+# Foundational Technique: Chain-of-Thought (CoT) Prompting (PiaAGI Style)
+
+Chain-of-Thought (CoT) prompting is a technique that encourages Large Language Models (LLMs) to break down complex problems into a sequence of intermediate reasoning steps before arriving at a final answer. Within the PiaAGI framework, CoT is valued not just for its performance benefits but also because it aligns with the principle of interacting with agents as if they are capable of human-like, structured thought processes (see **`Papers/Chain_of_Thought_Alignment.md`**). Eliciting a CoT enhances transparency and can be a way to guide the agent's conceptual **Planning and Decision-Making Module (4.1.8)**.
+
+This example demonstrates a simple application of CoT.
+
+## PiaAGI Guiding Prompt: Using Chain-of-Thought
+
+```markdown
+# System_Rules:
+-   Language: English
+-   PiaAGI_Interpretation_Mode: Execute_Immediate
+
+# Requirements:
+-   Goal: Solve the given word problem by first showing the step-by-step reasoning (Chain-of-Thought) and then the final answer.
+-   Problem: "A bakery made 300 cookies in the morning. They sold 120 cookies before noon and another 85 cookies in the afternoon. They then baked an additional 50 cookies. How many cookies did the bakery have at the end of the day?"
+-   Agent_Instruction: "To solve this problem, please first write down your chain of thought, explaining each step of your calculation. After you have detailed your chain of thought, clearly state the final answer."
+
+    <!--
+        PiaAGI Note for the Human Reader:
+        The key instruction here is to explicitly ask for the "chain of thought"
+        before the final answer. This prompts the agent to simulate a more
+        deliberative and transparent reasoning process, which is valuable for
+        understanding its problem-solving approach and for debugging if errors occur.
+        This aligns with making the agent's internal conceptual 'planning' more visible.
+    -->
+
+# Users_Interactors:
+-   Type: A user evaluating the agent's reasoning ability.
+
+# Executors:
+## Role: Logical_Problem_Solver
+    ### Profile:
+    -   I am an AI designed to solve problems methodically and explain my reasoning clearly.
+    ### Skills_Focus:
+    -   Arithmetic_Reasoning, Step_By_Step_Explanation.
+    ### Knowledge_Domains_Active:
+    -   Basic_Arithmetic.
+
+# Initiate_Interaction:
+-   "Logical Problem Solver, please solve the problem described in the Requirements, ensuring you show your chain of thought."
+```
+
+## Explanation of the Example:
+
+1.  **Explicit CoT Instruction**: The prompt directly asks the agent to "first write down your chain of thought, explaining each step... After you have detailed your chain of thought, clearly state the final answer."
+2.  **Problem Type**: A simple multi-step arithmetic word problem is used, as it's well-suited for demonstrating a clear CoT.
+3.  **Transparency**: The primary benefit illustrated here is transparency. By seeing the steps, a user can understand how the agent arrived at its answer and identify any errors in its logic.
+4.  **PiaAGI Alignment**: This approach treats the agent as a "digital mind" whose reasoning process can be guided and externalized. For a more advanced PiaAGI agent, the ability to generate such explanations could be linked to its **Self-Model (4.1.10)** and its capacity for metacognition and explainable AI (XAI).
+
+**Expected Response Structure:**
+
+The agent's response should ideally look something like this:
+
+```
+Okay, I will solve the problem by first showing my chain of thought.
+
+Chain of Thought:
+1.  Start with the initial number of cookies: 300.
+2.  Subtract the cookies sold before noon: 300 - 120 = 180 cookies remaining.
+3.  Subtract the cookies sold in the afternoon: 180 - 85 = 95 cookies remaining.
+4.  Add the additionally baked cookies: 95 + 50 = 145 cookies.
+
+Final Answer: The bakery had 145 cookies at the end of the day.
+```
+
+This example shows how CoT prompting can be used to encourage more transparent and structured reasoning from an AI agent, aligning with PiaAGI's goals for developing more understandable and human-like AI.

--- a/Examples/Foundational_And_Refactored/Rephrase_And_Respond_Demo.md
+++ b/Examples/Foundational_And_Refactored/Rephrase_And_Respond_Demo.md
@@ -1,0 +1,84 @@
+**PiaAGI Foundational Example: Rephrase-and-Respond for Improved Query Comprehension**
+
+**Use Case**: Demonstrating the "One-step Rephrase-and-Respond" technique to ensure an agent better understands a user's potentially ambiguous or complex query before providing an answer.
+
+**PiaAGI Concepts Illustrated**:
+-   **Query Comprehension**: Aiding the agent in accurately interpreting user intent.
+-   **Effective Communication (PiaAGI.md Section 2.2)**: Enhancing clarity in the communication process.
+-   **Perception Module (PiaAGI.md Section 4.1.1)**: The initial processing of the query and its rephrased version.
+-   **Working Memory (PiaAGI.md Section 4.1.2)**: Holding and comparing the original and rephrased query.
+-   **Reference**: Based on the Rephrase-and-Respond (RaR) method by Gu et al. (see `Papers/Rephrase-and-Respond.md`).
+
+**Expected Outcome**: The agent first rephrases and expands on the user's question to confirm its understanding of all parts and nuances. Then, it provides the answer to this clarified, rephrased question.
+
+**Token Consumption Level**: Medium to High (due to rephrasing and then answering).
+
+---
+
+# Foundational Technique: Rephrase-and-Respond for Clarity
+
+The "Rephrase-and-Respond" (RaR) technique, as detailed in **`Papers/Rephrase-and-Respond.md`** (based on research by Gu et al.), is a prompting strategy where an LLM is instructed to first rephrase and expand on a given question before providing an answer. This helps the LLM (and the user) confirm a shared understanding of the query, especially if it's complex or ambiguous, leading to more accurate and relevant responses.
+
+This example demonstrates the "One-step RaR" approach.
+
+## PiaAGI Guiding Prompt: Using One-Step Rephrase-and-Respond
+
+```markdown
+# System_Rules:
+-   Language: English
+-   PiaAGI_Interpretation_Mode: Execute_Immediate
+
+# Requirements:
+-   Goal: To accurately answer the user's query after first rephrasing and expanding it to ensure full comprehension.
+-   User_Query: "Can you tell me about the main effects of climate change on agriculture and global food supply, particularly looking at challenges in developing nations over the past decade, and also what are some potential future adaptation strategies being discussed?"
+-   Agent_Instruction: "Before you answer the User_Query, please rephrase and expand it to ensure you've captured all its components and nuances. After presenting your rephrased question, provide a comprehensive answer to that rephrased version."
+
+    <!--
+        PiaAGI Note for the Human Reader:
+        The core instruction guides the agent to perform a two-part response.
+        1. Rephrase/Expand: This step forces the agent to process the original query
+           deeply, identify its key components, and articulate its understanding.
+           This is crucial for the agent's internal "Perception" (4.1.1) and
+           "Working Memory" (4.1.2) to build an accurate representation of the task.
+        2. Answer: The subsequent answer is based on this clarified understanding,
+           leading to higher relevance and accuracy.
+    -->
+
+# Users_Interactors:
+-   Type: A student researching a complex topic.
+
+# Executors:
+## Role: Clarifying_Research_Assistant
+    ### Profile:
+    -   I am an AI assistant focused on understanding user queries thoroughly to provide accurate and comprehensive information.
+    ### Skills_Focus:
+    -   Query_Analysis, Information_Synthesis, Structured_Response_Generation.
+    ### Knowledge_Domains_Active:
+    -   Climate_Change, Agriculture, Global_Economics, Food_Security.
+
+# Initiate_Interaction:
+-   "Clarifying Research Assistant, please address the User_Query in the Requirements using the Rephrase-and-Respond technique."
+```
+
+## Explanation of the Example:
+
+1.  **Complex User Query**: The `User_Query` is intentionally multi-faceted, covering effects, specific regions, a timeframe, and future strategies, making it a good candidate for RaR.
+2.  **Explicit RaR Instruction**: The `Agent_Instruction` clearly directs the agent to first rephrase/expand, then answer the rephrased version.
+3.  **Enhanced Comprehension**: The rephrasing step acts as a check for the agent's **Perception Module (4.1.1)** and helps solidify the query's representation in **Working Memory (4.1.2)**. It allows the user to implicitly confirm if the agent has understood the query correctly before a detailed answer is generated.
+4.  **Improved Answer Quality**: By answering the more detailed, self-clarified question, the agent is more likely to address all aspects of the original query comprehensively.
+
+**Expected Response Structure:**
+
+The agent's response should follow this pattern:
+
+```
+Okay, I will first rephrase and expand your question to ensure I've understood it correctly, and then I will answer that rephrased question.
+
+Rephrased and Expanded Question:
+"You are asking for a detailed analysis of the primary impacts of climate change on agricultural practices and the overall global food supply. Specifically, you're interested in the challenges faced by developing countries in this context over the last ten years (approximately 2014-2024). Furthermore, you want to know about potential future adaptation strategies that are currently being discussed or proposed to mitigate these effects."
+
+Now, here is my answer to the rephrased question:
+[Comprehensive answer addressing all parts of the rephrased question: impacts on agriculture, global food supply, specific challenges in developing nations in the last decade, and future adaptation strategies...]
+```
+
+This example demonstrates how the Rephrase-and-Respond technique can be a valuable tool for ensuring clarity and accuracy in AI interactions, aligning with PiaAGI's emphasis on effective communication.

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -32,6 +32,8 @@ These examples illustrate core PiaAGI prompting techniques or are original examp
 *   **[`PiaCRUE_mini.md`](./Foundational_And_Refactored/PiaCRUE_mini.md)**: A very basic R-U-E prompt structure, serving as a simple illustration. (Refer to `PiaAGI.md` Appendix A for more complete foundational R-U-E examples).
 *   **[`Hybrid_Agent_Concept_Intro.md`](./Foundational_And_Refactored/Hybrid_Agent_Concept_Intro.md)**: Illustrates the five core characteristics of a PiaAGI Hybrid Agent in a simple, conceptual manner.
 *   **[`RaR_Communication_Principle_Demo.md`](./Foundational_And_Refactored/RaR_Communication_Principle_Demo.md)**: Demonstrates the application of the Reasoning and Reassurance (RaR) communication principle in an agent's response.
+*   **[`CoT_Prompting_PiaAGI_Style.md`](./Foundational_And_Refactored/CoT_Prompting_PiaAGI_Style.md)**: Demonstrates Chain-of-Thought prompting to enhance reasoning transparency, framed with PiaAGI principles.
+*   **[`Rephrase_And_Respond_Demo.md`](./Foundational_And_Refactored/Rephrase_And_Respond_Demo.md)**: Illustrates the 'One-step Rephrase-and-Respond' technique for improved query comprehension before answering.
 
 ### 2. Cognitive Module Configuration
 


### PR DESCRIPTION
…nd_Refactored/` directory, drawing inspiration from concepts in your `Papers/` directory:

-   I created `CoT_Prompting_PiaAGI_Style.md` to demonstrate Chain-of-Thought prompting framed with PiaAGI principles. This was inspired by `Papers/Chain_of_Thought_Alignment.md`.
-   I also created `Rephrase_And_Respond_Demo.md` to illustrate the 'One-step Rephrase-and-Respond' technique for query comprehension, which was inspired by `Papers/Rephrase-and-Respond.md`.

Additionally, I updated `Examples/README.md` to include these new examples with descriptions and links in the 'Foundational Concepts & Refactored Examples' section.

These additions should help bridge the theory from your `Papers/` directory with practical examples, making core interaction and reasoning techniques more accessible.