### PR TITLE
Feat: Add conceptual design for CML module integration example

### DIFF
--- a/Examples/Conceptual_Integrations/Simple_Command_Response_Cycle.md
+++ b/Examples/Conceptual_Integrations/Simple_Command_Response_Cycle.md
@@ -1,0 +1,159 @@
+<!-- PiaAGI Conceptual Integration Example -->
+# Conceptual Integration Example: Simple Command Response Cycle
+
+**Date:** November 23, 2024
+**Author:** PiaAGI Project Contributor (Jules)
+**Related PiaAGI Sections:** [PiaAGI.md Section 4.1 (Core Modules)](../../PiaAGI.md#41-core-modules-and-their-interactions), [PiaAGI.md Section 4.2 (Information Flow)](../../PiaAGI.md#42-information-flow-and-processing), [PiaAGI_Research_Tools/PiaCML/](../../PiaAGI_Research_Tools/PiaCML/)
+
+## 1. Introduction
+
+This document outlines a conceptual example of how core cognitive modules from the PiaAGI Cognitive Module Library (CML) might interact to process a simple user command and generate a response. It illustrates a basic perception-cognition-action cycle within the PiaAGI framework.
+
+The purpose is to provide a clear, step-by-step walkthrough of data flow and module responsibilities, serving as a conceptual blueprint for future CML implementation, testing, and more complex scenario development in PiaSE.
+
+## 2. Scenario Definition
+
+*   **Name:** "Basic Fact Retrieval and Description"
+*   **Agent's Goal:** To receive a simple request for information about a known object, retrieve relevant facts from its knowledge base, and provide a concise descriptive textual response.
+*   **User Input:** User provides a textual command: `"Pia, tell me about a red apple."`
+*   **Expected Agent Output (Example):** Agent provides a textual response, e.g., `"A red apple is a fruit that is typically red, grows on trees, and is crisp, juicy, and can be sweet or tart."`
+
+## 3. Core CML Modules Involved
+
+For this scenario, the following (conceptual) concrete CML modules are primarily involved:
+
+1.  **`ConcretePerceptionModule`**: Processes the raw user command.
+2.  **`ConcreteWorkingMemoryModule` (including Central Executive functions)**: Holds task-relevant information and coordinates module interactions.
+3.  **`ConcreteLongTermMemoryModule` (Semantic Memory aspect)**: Stores and retrieves factual knowledge.
+4.  **`ConcretePlanningAndDecisionMakingModule` (Simplified Role)**: Structures the information for the response.
+5.  **`ConcreteCommunicationModule`**: Generates the natural language response.
+6.  **`ConcreteBehaviorGenerationModule`**: Executes the communicative act (outputs the text).
+
+## 4. Conceptual Data Flow and Module Interactions
+
+The interaction unfolds in the following sequence:
+
+**Step 1: Input Reception & Initial Processing (Perception)**
+
+*   **Input:** Raw text from user: `"Pia, tell me about a red apple."`
+*   **Module:** `ConcretePerceptionModule`
+    *   **Method Invoked (Conceptual):** `process_sensory_input(data="Pia, tell me about a red apple.", modality="text")`
+    *   **Processing:** Performs basic Natural Language Understanding (NLU) to identify intent and key entities.
+    *   **Output (Conceptual Structured Representation):**
+        ```json
+        {
+          "type": "linguistic_input",
+          "parsed_command": {
+            "agent_name_detected": "Pia",
+            "intent": "request_information",
+            "entities": [
+              {"name": "apple", "type": "object"},
+              {"name": "red", "type": "attribute", "modifies": "apple"}
+            ],
+            "action_verb": "tell me about"
+          },
+          "original_text": "Pia, tell me about a red apple."
+        }
+        ```
+    *   **Next Step:** This structured output is passed to the Working Memory Module.
+
+**Step 2: Information Holding & Coordination (Working Memory)**
+
+*   **Module:** `ConcreteWorkingMemoryModule`
+    *   **Method Invoked (Conceptual):** `add_item_to_workspace(item_data=<structured_output_from_perception>, salience=high)`
+    *   **Internal State:** The parsed command (e.g., `wm_item_id_1`) is now held in the workspace.
+    *   **Central Executive (Conceptual Function):**
+        *   Analyzes `wm_item_id_1`, recognizes the `request_information` intent.
+        *   Determines that knowledge retrieval from LTM is required.
+        *   Formulates a query for LTM based on the entities ("apple", "red").
+    *   **Method Invoked (Conceptual):** `set_active_focus(item_id=wm_item_id_1)` to keep the task context active.
+
+**Step 3: Knowledge Retrieval (Long-Term Memory)**
+
+*   **Input to LTM:** A query from WM/Central Executive, e.g., `{"concept": "apple", "attributes": ["red"]}` or `{"concept": "red apple"}`.
+*   **Module:** `ConcreteLongTermMemoryModule` (Semantic aspect)
+    *   **Method Invoked (Conceptual):** `retrieve_semantic(query_concept="apple", attributes_filter=["red"])`
+    *   **Conceptual LTM Content (Example - Simplified):**
+        *   `memory_id_X: {type: semantic, concept: "apple", data: {is_a: "fruit", grows_on: "trees", typical_color: ["red", "green"], taste: ["sweet", "tart"], texture: ["crisp", "juicy"]}}`
+        *   `memory_id_Z: {type: semantic, concept: "red apple", data: {is_a: "apple", color: "red", specific_taste_notes: ["often sweeter"]}}`
+    *   **Output (Conceptual Retrieved Facts, passed to WM):**
+        ```json
+        {
+          "retrieved_facts": [
+            {"source_id": "memory_id_Z", "fact_key": "is_a_apple", "value": true},
+            {"source_id": "memory_id_Z", "fact_key": "color_is_red", "value": true},
+            {"source_id": "memory_id_Z", "fact_key": "taste_often_sweeter", "value": true},
+            {"source_id": "memory_id_X", "fact_key": "is_a_fruit", "value": true},
+            {"source_id": "memory_id_X", "fact_key": "grows_on_trees", "value": true},
+            {"source_id": "memory_id_X", "fact_key": "texture_crisp", "value": true},
+            {"source_id": "memory_id_X", "fact_key": "texture_juicy", "value": true},
+            {"source_id": "memory_id_X", "fact_key": "taste_sweet_or_tart", "value": true}
+          ],
+          "query_success": true
+        }
+        ```
+*   **Module:** `ConcreteWorkingMemoryModule`
+    *   **Method Invoked (Conceptual):** `add_item_to_workspace(item_data=<retrieved_facts_from_LTM>, salience=high)`
+    *   **Internal State:** `wm_item_id_2` now holds these facts. The Central Executive notes that information for the response has been gathered.
+
+**Step 4: Response Structuring (Planning & Decision-Making - Simplified)**
+
+*   **Input to Planning:** The `request_information` intent and `retrieved_facts` from WM.
+*   **Module:** `ConcretePlanningAndDecisionMakingModule`
+    *   **Method Invoked (Conceptual):** `create_plan(goal_description={"intent": "describe_object", "object_details": <retrieved_facts_from_wm_item_id_2>})`
+    *   **Processing:** Selects the most relevant facts and orders them for a coherent description. Filters or combines facts as needed.
+    *   **Output (Conceptual "Plan" / Response Structure):**
+        ```json
+        {
+          "plan_id": "plan_123",
+          "type": "communication_plan",
+          "discourse_goal": "inform",
+          "selected_facts_for_response": [
+            {"key": "is_a_fruit", "statement_template": "A red apple is a {value}."},
+            {"key": "color_is_red", "statement_template": "It is {value} in color."},
+            {"key": "grows_on_trees", "statement_template": "It grows on {value}."},
+            {"key": "texture_crisp_juicy", "statement_template": "Its texture is typically {value1} and {value2}."},
+            {"key": "taste_sweet_or_tart", "statement_template": "It can be {value1} or {value2}."}
+          ]
+        }
+        ```
+    *   **Method Invoked (Conceptual):** `select_action_or_plan(evaluated_plans=[<plan_123_with_conceptual_score>])` returns `plan_123`.
+    *   **Next Step:** This selected response structure is passed back to WM (or directly to Communication Module).
+
+**Step 5: Natural Language Generation (Communication)**
+
+*   **Input to Communication:** The `plan_123` (response structure) from WM.
+*   **Module:** `ConcreteCommunicationModule`
+    *   **Method Invoked (Conceptual):** `generate_outgoing_communication(content_to_express=<plan_123>, target_interlocutor_id="user_xyz", strategy_hint="informative_description")`
+    *   **Processing:** Uses templates or NLG techniques to weave the selected facts into natural-sounding prose.
+    *   **Output (Conceptual Natural Language Text):**
+        `"A red apple is a fruit. It is red in color. It grows on trees. Its texture is typically crisp and juicy. It can be sweet or tart."`
+        *(A more advanced NLG might combine these better, e.g., "A red apple is a red fruit that grows on trees, typically crisp, juicy, and can be sweet or tart.")*
+    *   **Next Step:** This generated text is passed to the Behavior Generation Module.
+
+**Step 6: Output Execution (Behavior Generation)**
+
+*   **Input to Behavior Generation:** The generated text from the Communication Module.
+*   **Module:** `ConcreteBehaviorGenerationModule`
+    *   **Method Invoked (Conceptual):** `generate_behavior(action_plan_details={"type": "linguistic_output", "text": "<generated_text_from_communication_module>"})`
+    *   **Output (Conceptual):** The actual transmission of the text to the user interface or environment.
+        ```json
+        {
+          "behavior_type": "communicate",
+          "content_type": "text",
+          "content": "A red apple is a fruit. It is red in color. It grows on trees. Its texture is typically crisp and juicy. It can be sweet or tart.",
+          "target": "user_xyz"
+        }
+        ```
+
+## 5. Conclusion
+
+This conceptual walkthrough demonstrates a plausible sequence of interactions among core CML modules for a simple command-response task. It highlights:
+*   The transformation of data from raw input to structured representations and finally to natural language output.
+*   The distinct roles of each module in the cognitive process.
+*   The importance of Working Memory and Central Executive functions in coordinating information flow.
+
+This example provides a basis for further refinement of CML module interfaces and for developing more complex interaction scenarios for PiaAGI agents.
+
+---
+Return to [PiaAGI Core Document](../../PiaAGI.md) | [Examples README](../README.md)

--- a/ToDoList.md
+++ b/ToDoList.md
@@ -2,6 +2,7 @@
 
 - [x] Reorganize root `img/` directory: Moved all images to `docs/assets/img/` and updated all markdown references. Removed root `img/` directory. (Task completed on 2024-07-29)
 - [x] Re-evaluate `conceptual_simulations` directory: Moved contents (`diagram_descriptions.md` to `docs/assets/`, `PiaAGI_Behavior_Example.py` to `Examples/`) and removed the directory as it's not a standalone tool following PiaXYZ naming. (Task completed on 2024-07-29)
+- [x] Completed Project Review, Documentation Update, and Next Steps Definition (Nov 2024). This led to the current detailed conceptual tasks for tools and examples.
 - [x] Create a new file named `PiaAGI.md` in the root of the repository. (Placeholder, original task)
 - [x] Add the following content to `PiaAGI.md`: (Placeholder, original task)
   ```markdown
@@ -73,7 +74,8 @@
 - [x] CML: Implement foundational interfaces/ABCs for EmotionModule. (Base class/interface defined)
 - [x] CML: Implement foundational interfaces/ABCs for PlanningAndDecisionMakingModule. (Base class/interface defined)
 - [x] CML: Implement foundational interfaces/ABCs for SelfModelModule. (Base class/interface defined)
-- [ ] Develop conceptual design for an integration example of combined CML modules (e.g., Perception-WM-LTM-Planning-BehaviorGeneration loop).
+- [x] Developed conceptual design for an integration example of combined CML modules (Simple_Command_Response_Cycle.md).
+- [ ] Review and refine conceptual integration example (Examples/Conceptual_Integrations/Simple_Command_Response_Cycle.md).
 - [ ] Conceptually detail enhancements for 1-2 Concrete CML Modules (e.g., ConcreteLTM retrieval strategies, ConcreteMotivationalSystem intrinsic goal triggering).
 - [ ] Define BaseWorldModel interface and ConcreteWorldModel structure, detailing components and interaction patterns with other CML modules.
 


### PR DESCRIPTION
This commit introduces a conceptual design for an integration example of core CML modules.

Key changes include:

1.  **New Conceptual Example Document:**
    *   I created `Examples/Conceptual_Integrations/Simple_Command_Response_Cycle.md`.
    *   This document details a "Basic Fact Retrieval and Description" scenario, identifies the CML modules involved (Perception, WM, LTM, Planning, Communication, Behavior Generation), and outlines the step-by-step conceptual data flow and module interactions for processing a simple user command and generating a response.

2.  **`ToDoList.md` Update:**
    *   I marked the task "Develop conceptual design for an integration example of combined CML modules" as complete.
    *   I added a new task: "- [ ] Review and refine conceptual integration example (Examples/Conceptual_Integrations/Simple_Command_Response_Cycle.md)."
    *   I added a general task reflecting the completion of the previous overarching project review and planning phase: "- [x] Completed Project Review, Documentation Update, and Next Steps Definition (Nov 2024). This led to the current detailed conceptual tasks for tools and examples."

This conceptual example serves as a blueprint for future CML implementation, testing, and more complex scenario development within the PiaAGI framework.