### PR TITLE
feat(PiaCML): Implement Phase 1 Message Bus and conceptual integration

### DIFF
--- a/PiaAGI_Research_Tools/PiaCML/__init__.py
+++ b/PiaAGI_Research_Tools/PiaCML/__init__.py
@@ -1,10 +1,43 @@
 # This file makes PiaAGI_Research_Tools.PiaCML a Python package.
 
-# Optionally, you can make some classes/functions available directly from the package, e.g.:
-# from .core_messages import GenericMessage, MemoryItem
-# from .concrete_self_model_module import ConcreteSelfModelModule
-# ... and so on for other key modules/classes.
+# Expose key classes at the package level for easier imports.
 
-# For now, keeping it simple. Users can import using the full path, e.g.:
-# from PiaAGI_Research_Tools.PiaCML.core_messages import GenericMessage
-# from PiaAGI_Research_Tools.PiaCML.concrete_self_model_module import ConcreteSelfModelModule
+# Core message structures
+from .core_messages import (
+    GenericMessage,
+    MemoryItem,
+    PerceptDataPayload,
+    GoalUpdatePayload,
+    LTMQueryResultPayload
+    # Add other specific payloads here as they are defined and needed for top-level access
+)
+
+# Message Bus
+from .message_bus import MessageBus
+
+# Base classes for modules (examples, add all as needed)
+from .base_memory_module import BaseMemoryModule
+from .base_long_term_memory_module import BaseLongTermMemoryModule
+from .base_working_memory_module import BaseWorkingMemoryModule
+from .base_emotion_module import BaseEmotionModule
+from .base_motivational_system_module import BaseMotivationalSystemModule
+# ... add other base modules
+
+# Concrete module implementations (examples, add all as needed for direct import)
+from .concrete_self_model_module import ConcreteSelfModelModule
+from .concrete_long_term_memory_module import ConcreteLongTermMemoryModule
+from .concrete_working_memory_module import ConcreteWorkingMemoryModule
+from .concrete_emotion_module import ConcreteEmotionModule
+from .concrete_motivational_system_module import ConcreteMotivationalSystemModule
+# ... add other concrete modules
+
+# Optional: Define __all__ if you want to control `from PiaAGI_Research_Tools.PiaCML import *`
+__all__ = [
+    "GenericMessage", "MemoryItem", "PerceptDataPayload", "GoalUpdatePayload", "LTMQueryResultPayload",
+    "MessageBus",
+    "BaseMemoryModule", "BaseLongTermMemoryModule", "BaseWorkingMemoryModule",
+    "BaseEmotionModule", "BaseMotivationalSystemModule",
+    "ConcreteSelfModelModule", "ConcreteLongTermMemoryModule", "ConcreteWorkingMemoryModule",
+    "ConcreteEmotionModule", "ConcreteMotivationalSystemModule",
+    # Add other exposed class names here
+]

--- a/PiaAGI_Research_Tools/PiaCML/message_bus.py
+++ b/PiaAGI_Research_Tools/PiaCML/message_bus.py
@@ -1,0 +1,162 @@
+from typing import Dict, Callable, List, Any, DefaultDict
+from collections import defaultdict
+
+# Attempt relative import, common for package structures
+try:
+    from .core_messages import GenericMessage
+except ImportError:
+    # Fallback for scenarios where the script might be run directly
+    # or the environment setup makes relative imports tricky without full package install
+    from core_messages import GenericMessage
+
+class MessageBus:
+    """
+    A simple message bus for inter-module communication within PiaCML.
+    Modules can subscribe to specific message types and publish messages to the bus.
+    """
+    def __init__(self):
+        """
+        Initializes the MessageBus.
+        _subscribers is a dictionary where keys are message_types (str)
+        and values are lists of tuples, each containing (module_id, callback_function).
+        """
+        # Stores subscribers: message_type -> list of (module_id, callback_function)
+        self._subscribers: DefaultDict[str, List[tuple[str, Callable[[GenericMessage], None]]]] = defaultdict(list)
+        # print("MessageBus initialized.") # Optional: for debugging initialization
+
+    def subscribe(self, module_id: str, message_type: str, callback: Callable[[GenericMessage], None]):
+        """
+        Subscribes a module to a specific message type.
+
+        Args:
+            module_id: The identifier of the subscribing module.
+            message_type: The type of message to subscribe to (e.g., "PerceptData").
+            callback: The function to call when a message of this type is published.
+                      The callback should accept a GenericMessage object.
+        """
+        # print(f"Module '{module_id}' attempting to subscribe to message type '{message_type}'") # Optional
+
+        # Avoid duplicate subscriptions for the same module_id and callback to the same message_type
+        for sub_module_id, sub_callback in self._subscribers[message_type]:
+            if sub_module_id == module_id and sub_callback == callback:
+                # print(f"Module '{module_id}' already subscribed to '{message_type}' with this callback.") # Optional
+                return
+        self._subscribers[message_type].append((module_id, callback))
+        # print(f"Module '{module_id}' successfully subscribed to '{message_type}'.") # Optional
+
+    def publish(self, message: GenericMessage):
+        """
+        Publishes a message to all subscribed modules for that message type.
+
+        Args:
+            message: The GenericMessage object to publish.
+        """
+        message_type = message.message_type
+        # print(f"Publishing message type '{message_type}' from '{message.source_module_id}' with ID '{message.message_id}'") # Optional
+
+        # Iterate over a copy of the subscriber list for safety,
+        # in case a callback tries to subscribe/unsubscribe during iteration.
+        subscribers_to_notify = list(self._subscribers.get(message_type, []))
+
+        if not subscribers_to_notify:
+            # print(f"No subscribers for message type '{message_type}'.") # Optional
+            return
+
+        for module_id, callback in subscribers_to_notify:
+            try:
+                # print(f"  Notifying module '{module_id}' for message type '{message_type}'") # Optional
+                callback(message)
+            except Exception as e:
+                print(f"Error in callback for module '{module_id}' processing message type '{message_type}' (msg_id: {message.message_id}): {e}")
+                # Potentially add more robust error handling or logging here,
+                # e.g., logging the traceback.
+
+    def unsubscribe(self, module_id: str, message_type: str, callback: Callable[[GenericMessage], None]):
+        """
+        Unsubscribes a module from a specific message type and callback.
+
+        Args:
+            module_id: The identifier of the unsubscribing module.
+            message_type: The type of message to unsubscribe from.
+            callback: The specific callback function to remove.
+        """
+        if message_type in self._subscribers:
+            original_count = len(self._subscribers[message_type])
+            self._subscribers[message_type] = [
+                (sub_mod_id, sub_call) for sub_mod_id, sub_call in self._subscribers[message_type]
+                if not (sub_mod_id == module_id and sub_call == callback)
+            ]
+            if len(self._subscribers[message_type]) < original_count:
+                pass
+                # print(f"Module '{module_id}' unsubscribed from '{message_type}' with specific callback.") # Optional
+            # else:
+                # print(f"Module '{module_id}' with callback not found for unsubscribe from '{message_type}'.") # Optional
+        # else:
+            # print(f"No subscribers for message type '{message_type}' to unsubscribe module '{module_id}'.") # Optional
+
+
+    def get_subscribers_for_type(self, message_type: str) -> List[tuple[str, Callable[[GenericMessage], None]]]:
+        """
+        Returns a list of (module_id, callback) tuples for a given message type.
+        Mainly for introspection or debugging.
+        """
+        return list(self._subscribers.get(message_type, [])) # Return a copy
+
+if __name__ == '__main__':
+    # Example Usage (manual test)
+    from core_messages import PerceptDataPayload # Assuming core_messages.py is in the same directory for direct run
+    import datetime
+    import uuid
+
+    print("--- MessageBus Example Usage ---")
+    bus = MessageBus()
+
+    # Define some callback functions
+    def module_a_listener(message: GenericMessage):
+        print(f"Module A received: Type='{message.message_type}', Payload='{message.payload}', Source='{message.source_module_id}'")
+
+    def module_b_listener_percept(message: GenericMessage):
+        if isinstance(message.payload, PerceptDataPayload):
+            print(f"Module B (Percept Listener) received Percept: Modality='{message.payload.modality}', Content='{message.payload.content}'")
+        else:
+            print(f"Module B (Percept Listener) received unexpected payload type for PerceptData message: {type(message.payload)}")
+
+    def module_b_listener_general(message: GenericMessage):
+        print(f"Module B (General Listener) received: Type='{message.message_type}', Payload='{message.payload}'")
+
+
+    # Subscribe modules
+    bus.subscribe(module_id="ModA", message_type="SYSTEM_STATUS", callback=module_a_listener)
+    bus.subscribe(module_id="ModB_Percept", message_type="PerceptData", callback=module_b_listener_percept)
+    bus.subscribe(module_id="ModB_General", message_type="SYSTEM_STATUS", callback=module_b_listener_general)
+    bus.subscribe(module_id="ModA", message_type="PerceptData", callback=module_a_listener) # ModA also listens to PerceptData
+
+    # Publish some messages
+    print("\n--- Publishing Messages ---")
+    status_payload = {"status": "nominal", "load": 0.3}
+    status_message = GenericMessage(source_module_id="SystemMonitor", message_type="SYSTEM_STATUS", payload=status_payload)
+    bus.publish(status_message)
+
+    percept_content = {"detected_objects": ["cat", "mat"], "confidence": 0.88}
+    percept_payload_obj = PerceptDataPayload(
+        percept_id=str(uuid.uuid4()),
+        modality="visual",
+        content=percept_content,
+        source_timestamp=datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(milliseconds=100)
+    )
+    percept_message = GenericMessage(source_module_id="VisionSystem", message_type="PerceptData", payload=percept_payload_obj)
+    bus.publish(percept_message)
+
+    # Test duplicate subscription avoidance
+    print("\n--- Testing Duplicate Subscription ---")
+    bus.subscribe(module_id="ModA", message_type="SYSTEM_STATUS", callback=module_a_listener) # Already subscribed
+    # Check number of subscribers for SYSTEM_STATUS (should be 2: ModA's module_a_listener, ModB_General's module_b_listener_general)
+    print(f"Subscribers for SYSTEM_STATUS: {len(bus.get_subscribers_for_type('SYSTEM_STATUS'))}") # Expected 2
+
+    # Test unsubscribe
+    print("\n--- Testing Unsubscribe ---")
+    bus.unsubscribe(module_id="ModA", message_type="SYSTEM_STATUS", callback=module_a_listener)
+    print(f"Subscribers for SYSTEM_STATUS after ModA unsub: {len(bus.get_subscribers_for_type('SYSTEM_STATUS'))}") # Expected 1
+    bus.publish(status_message) # ModA should not receive this status_message now
+
+    print("\nExample Usage Complete.")

--- a/PiaAGI_Research_Tools/PiaCML/tests/test_concrete_working_memory_module.py
+++ b/PiaAGI_Research_Tools/PiaCML/tests/test_concrete_working_memory_module.py
@@ -14,33 +14,124 @@ except ImportError:
 class TestConcreteWorkingMemoryModule(unittest.TestCase):
 
     def setUp(self):
-        self.wm = ConcreteWorkingMemoryModule(capacity=3) # Use a small capacity for easier testing
+        self.bus = MessageBus() # Real bus for testing subscription
+        self.wm_no_bus = ConcreteWorkingMemoryModule(capacity=3) # For tests not needing a bus
+        self.wm_with_bus = ConcreteWorkingMemoryModule(capacity=3, message_bus=self.bus)
+
         self._original_stdout = sys.stdout
-        sys.stdout = open(os.devnull, 'w')
+        # Comment out print suppression for easier debugging if tests fail
+        # sys.stdout = open(os.devnull, 'w')
 
     def tearDown(self):
-        sys.stdout.close()
+        # sys.stdout.close()
         sys.stdout = self._original_stdout
 
     def test_initial_status(self):
-        status = self.wm.get_status()
+        # Test instance without bus
+        status_no_bus = self.wm_no_bus.get_status()
+        self.assertEqual(status_no_bus['current_size'], 0)
+        self.assertEqual(status_no_bus['capacity'], 3)
+        self.assertIsNone(status_no_bus['current_focus_id'])
+        self.assertEqual(status_no_bus['module_type'], 'ConcreteWorkingMemoryModule')
+        self.assertIsNone(self.wm_no_bus.message_bus)
+        self.assertEqual(len(self.wm_no_bus.received_percepts), 0)
+
+        # Test instance with bus
+        status_with_bus = self.wm_with_bus.get_status()
+        self.assertEqual(status_with_bus['current_size'], 0)
+        self.assertEqual(status_with_bus['capacity'], 3)
+        self.assertIsNotNone(self.wm_with_bus.message_bus)
+        self.assertEqual(len(self.wm_with_bus.received_percepts), 0)
+        # Check subscription
+        subscribers = self.bus.get_subscribers_for_type("PerceptData")
+        self.assertTrue(any(sub[0] == "ConcreteWorkingMemoryModule_01" and sub[1] == self.wm_with_bus.handle_percept_data_message for sub in subscribers))
+
+    # --- Tests for MessageBus Integration ---
+    def test_handle_percept_data_message(self):
+        """Test that WM receives and stores PerceptData messages from the bus."""
+        self.assertEqual(len(self.wm_with_bus.received_percepts), 0)
+
+        source_ts = datetime.datetime.now(datetime.timezone.utc)
+        payload_content = {"info": "test percept from bus"}
+        percept_payload = PerceptDataPayload(
+            modality="test_modality",
+            content=payload_content,
+            source_timestamp=source_ts
+        )
+        test_message = GenericMessage(
+            source_module_id="TestPerceptionModule",
+            message_type="PerceptData",
+            payload=percept_payload
+        )
+
+        self.bus.publish(test_message) # Publish to the bus WM is subscribed to
+
+        self.assertEqual(len(self.wm_with_bus.received_percepts), 1)
+        received_msg = self.wm_with_bus.received_percepts[0]
+
+        self.assertIsInstance(received_msg, GenericMessage)
+        self.assertEqual(received_msg.message_id, test_message.message_id)
+        self.assertEqual(received_msg.message_type, "PerceptData")
+        self.assertIsInstance(received_msg.payload, PerceptDataPayload)
+        self.assertEqual(received_msg.payload.content, payload_content)
+
+    def test_no_subscription_if_bus_is_none(self):
+        """Test that WM does not attempt to subscribe if no bus is provided."""
+        # self.wm_no_bus was initialized with message_bus=None
+        # Publish a message on a new bus; wm_no_bus should not receive it.
+        local_bus = MessageBus() # A bus wm_no_bus knows nothing about
+
+        source_ts = datetime.datetime.now(datetime.timezone.utc)
+        percept_payload = PerceptDataPayload(
+            modality="text",
+            content="message for no-bus WM",
+            source_timestamp=source_ts
+        )
+        test_message = GenericMessage(
+            source_module_id="TestPerceptionModule",
+            message_type="PerceptData",
+            payload=percept_payload
+        )
+        local_bus.publish(test_message)
+
+        self.assertEqual(len(self.wm_no_bus.received_percepts), 0) # Should remain empty
+
+    def test_handle_malformed_message_gracefully(self):
+        """Test that the callback handles messages not matching expected structure."""
+        malformed_message = GenericMessage(
+            source_module_id="TestPerceptionModule",
+            message_type="PerceptData", # Correct type, but payload might be wrong
+            payload="This is just a string, not PerceptDataPayload"
+        )
+        self.bus.publish(malformed_message)
+        self.assertEqual(len(self.wm_with_bus.received_percepts), 1) # Message is still "received"
+        # Check the content of the received message in this error case
+        error_entry = self.wm_with_bus.received_percepts[0]
+        self.assertIsInstance(error_entry, dict) # The handler appends a dict on error
+        self.assertEqual(error_entry.get("error"), "AttributeError processing message")
+        self.assertTrue("This is just a string" in error_entry.get("raw_message", ""))
+
+
+    def test_initial_status_no_bus_instance(self): # Renamed for clarity
+    def test_initial_status_no_bus_instance(self): # Renamed for clarity
+        status = self.wm_no_bus.get_status() # Using wm_no_bus
         self.assertEqual(status['current_size'], 0)
         self.assertEqual(status['capacity'], 3)
         self.assertIsNone(status['current_focus_id'])
         self.assertEqual(status['module_type'], 'ConcreteWorkingMemoryModule')
 
     def test_add_item_and_get_contents(self):
-        id1 = self.wm.add_item_to_workspace({'data': 'item1'}, salience=0.5)
+        id1 = self.wm_no_bus.add_item_to_workspace({'data': 'item1'}, salience=0.5) # Using wm_no_bus
         self.assertRegex(id1, r"wm_item_\d+")
-        contents = self.wm.get_workspace_contents()
+        contents = self.wm_no_bus.get_workspace_contents() # Using wm_no_bus
         self.assertEqual(len(contents), 1)
         self.assertEqual(contents[0]['id'], id1)
         self.assertEqual(contents[0]['content'], {'data': 'item1'})
-        self.assertEqual(self.wm.get_status()['current_size'], 1)
+        self.assertEqual(self.wm_no_bus.get_status()['current_size'], 1) # Using wm_no_bus
 
     def test_store_method_as_add_item(self):
-        id_store = self.wm.store({'data': 'item_via_store'}, context={'salience': 0.6})
-        contents = self.wm.get_workspace_contents()
+        id_store = self.wm_no_bus.store({'data': 'item_via_store'}, context={'salience': 0.6}) # Using wm_no_bus
+        contents = self.wm_no_bus.get_workspace_contents() # Using wm_no_bus
         self.assertEqual(len(contents), 1)
         self.assertEqual(contents[0]['id'], id_store)
         self.assertEqual(contents[0]['content'], {'data': 'item_via_store'})
@@ -48,86 +139,86 @@ class TestConcreteWorkingMemoryModule(unittest.TestCase):
 
 
     def test_capacity_management_add_item(self):
-        id1 = self.wm.add_item_to_workspace("item1", 0.1)
-        id2 = self.wm.add_item_to_workspace("item2", 0.2)
-        id3 = self.wm.add_item_to_workspace("item3", 0.3)
-        self.assertEqual(self.wm.get_status()['current_size'], 3)
+        id1 = self.wm_no_bus.add_item_to_workspace("item1", 0.1) # Using wm_no_bus
+        id2 = self.wm_no_bus.add_item_to_workspace("item2", 0.2) # Using wm_no_bus
+        id3 = self.wm_no_bus.add_item_to_workspace("item3", 0.3) # Using wm_no_bus
+        self.assertEqual(self.wm_no_bus.get_status()['current_size'], 3) # Using wm_no_bus
 
         # This item has higher salience than item1, item1 should be removed
-        id4 = self.wm.add_item_to_workspace("item4", 0.4)
+        id4 = self.wm_no_bus.add_item_to_workspace("item4", 0.4) # Using wm_no_bus
         self.assertNotEqual(id4, "error_workspace_full")
 
-        contents = self.wm.get_workspace_contents()
+        contents = self.wm_no_bus.get_workspace_contents() # Using wm_no_bus
         self.assertEqual(len(contents), 3)
         item_ids = [item['id'] for item in contents]
         self.assertNotIn(id1, item_ids)
         self.assertIn(id4, item_ids)
 
         # This item has lower salience than all in workspace, should not be added
-        id5_fail = self.wm.add_item_to_workspace("item5_fail", 0.05)
+        id5_fail = self.wm_no_bus.add_item_to_workspace("item5_fail", 0.05) # Using wm_no_bus
         self.assertEqual(id5_fail, "error_workspace_full") # Assuming this is the error code for full
-        self.assertEqual(len(self.wm.get_workspace_contents()), 3)
-        self.assertNotIn(id5_fail, [item['id'] for item in self.wm.get_workspace_contents()])
+        self.assertEqual(len(self.wm_no_bus.get_workspace_contents()), 3) # Using wm_no_bus
+        self.assertNotIn(id5_fail, [item['id'] for item in self.wm_no_bus.get_workspace_contents()]) # Using wm_no_bus
 
 
     def test_remove_item_from_workspace(self):
-        id1 = self.wm.add_item_to_workspace("item1")
-        self.wm.add_item_to_workspace("item2")
-        self.assertTrue(self.wm.remove_item_from_workspace(id1))
-        self.assertEqual(self.wm.get_status()['current_size'], 1)
-        self.assertFalse(self.wm.remove_item_from_workspace(id1)) # Already removed
-        self.assertFalse(self.wm.remove_item_from_workspace("non_existent_id"))
+        id1 = self.wm_no_bus.add_item_to_workspace("item1") # Using wm_no_bus
+        self.wm_no_bus.add_item_to_workspace("item2") # Using wm_no_bus
+        self.assertTrue(self.wm_no_bus.remove_item_from_workspace(id1)) # Using wm_no_bus
+        self.assertEqual(self.wm_no_bus.get_status()['current_size'], 1) # Using wm_no_bus
+        self.assertFalse(self.wm_no_bus.remove_item_from_workspace(id1)) # Already removed Using wm_no_bus
+        self.assertFalse(self.wm_no_bus.remove_item_from_workspace("non_existent_id")) # Using wm_no_bus
 
 
     def test_delete_memory_as_remove_item(self):
-        id1 = self.wm.add_item_to_workspace("item1_del")
-        self.assertTrue(self.wm.delete_memory(id1))
-        self.assertEqual(self.wm.get_status()['current_size'], 0)
+        id1 = self.wm_no_bus.add_item_to_workspace("item1_del") # Using wm_no_bus
+        self.assertTrue(self.wm_no_bus.delete_memory(id1)) # Using wm_no_bus
+        self.assertEqual(self.wm_no_bus.get_status()['current_size'], 0) # Using wm_no_bus
 
 
     def test_set_and_get_active_focus(self):
-        id1 = self.wm.add_item_to_workspace("item_focus_1", 0.5)
-        id2 = self.wm.add_item_to_workspace("item_focus_2", 0.6)
+        id1 = self.wm_no_bus.add_item_to_workspace("item_focus_1", 0.5) # Using wm_no_bus
+        id2 = self.wm_no_bus.add_item_to_workspace("item_focus_2", 0.6) # Using wm_no_bus
 
-        self.assertTrue(self.wm.set_active_focus(id1))
-        focused_item = self.wm.get_active_focus()
+        self.assertTrue(self.wm_no_bus.set_active_focus(id1)) # Using wm_no_bus
+        focused_item = self.wm_no_bus.get_active_focus() # Using wm_no_bus
         self.assertIsNotNone(focused_item)
         self.assertEqual(focused_item['id'], id1)
         self.assertGreater(focused_item['salience'], 0.5) # Salience boosted
 
-        self.assertFalse(self.wm.set_active_focus("non_existent"))
-        self.assertIsNotNone(self.wm.get_active_focus()) # Focus should remain on id1
+        self.assertFalse(self.wm_no_bus.set_active_focus("non_existent")) # Using wm_no_bus
+        self.assertIsNotNone(self.wm_no_bus.get_active_focus()) # Focus should remain on id1 Using wm_no_bus
 
     def test_remove_focused_item_clears_focus(self):
-        id1 = self.wm.add_item_to_workspace("item_focus_rem", 0.7)
-        self.wm.set_active_focus(id1)
-        self.assertIsNotNone(self.wm.get_active_focus())
-        self.wm.remove_item_from_workspace(id1)
-        self.assertIsNone(self.wm.get_active_focus())
+        id1 = self.wm_no_bus.add_item_to_workspace("item_focus_rem", 0.7) # Using wm_no_bus
+        self.wm_no_bus.set_active_focus(id1) # Using wm_no_bus
+        self.assertIsNotNone(self.wm_no_bus.get_active_focus()) # Using wm_no_bus
+        self.wm_no_bus.remove_item_from_workspace(id1) # Using wm_no_bus
+        self.assertIsNone(self.wm_no_bus.get_active_focus()) # Using wm_no_bus
 
 
     def test_retrieve_by_id(self):
-        id1 = self.wm.add_item_to_workspace({'name': "Pia"}, 0.5)
-        retrieved = self.wm.retrieve({'id': id1})
+        id1 = self.wm_no_bus.add_item_to_workspace({'name': "Pia"}, 0.5) # Using wm_no_bus
+        retrieved = self.wm_no_bus.retrieve({'id': id1}) # Using wm_no_bus
         self.assertEqual(len(retrieved), 1)
         self.assertEqual(retrieved[0]['id'], id1)
 
     def test_retrieve_by_content_query(self):
-        self.wm.add_item_to_workspace({'type': 'fruit', 'name': 'apple'}, 0.5)
-        self.wm.add_item_to_workspace({'type': 'fruit', 'name': 'banana'}, 0.6)
-        self.wm.add_item_to_workspace({'type': 'veg', 'name': 'carrot'}, 0.7)
+        self.wm_no_bus.add_item_to_workspace({'type': 'fruit', 'name': 'apple'}, 0.5) # Using wm_no_bus
+        self.wm_no_bus.add_item_to_workspace({'type': 'fruit', 'name': 'banana'}, 0.6) # Using wm_no_bus
+        self.wm_no_bus.add_item_to_workspace({'type': 'veg', 'name': 'carrot'}, 0.7) # Using wm_no_bus
 
-        retrieved_fruits = self.wm.retrieve({'content_query': {'key': 'type', 'value': 'fruit'}})
+        retrieved_fruits = self.wm_no_bus.retrieve({'content_query': {'key': 'type', 'value': 'fruit'}}) # Using wm_no_bus
         self.assertEqual(len(retrieved_fruits), 2)
 
-        retrieved_apple = self.wm.retrieve({'content_query': {'key': 'name', 'value': 'apple'}})
+        retrieved_apple = self.wm_no_bus.retrieve({'content_query': {'key': 'name', 'value': 'apple'}}) # Using wm_no_bus
         self.assertEqual(len(retrieved_apple), 1)
         self.assertEqual(retrieved_apple[0]['content']['name'], 'apple')
 
     def test_retrieve_empty_query_returns_all(self):
-        id1 = self.wm.add_item_to_workspace("item_a")
-        id2 = self.wm.add_item_to_workspace("item_b")
-        all_items = self.wm.retrieve({})
+        id1 = self.wm_no_bus.add_item_to_workspace("item_a") # Using wm_no_bus
+        id2 = self.wm_no_bus.add_item_to_workspace("item_b") # Using wm_no_bus
+        all_items = self.wm_no_bus.retrieve({}) # Using wm_no_bus
         self.assertEqual(len(all_items), 2)
         item_ids = [item['id'] for item in all_items]
         self.assertIn(id1, item_ids)
@@ -135,48 +226,35 @@ class TestConcreteWorkingMemoryModule(unittest.TestCase):
 
 
     def test_manage_capacity_method(self):
-        # This method is mostly called internally by store/add_item, but test direct call
-        self.wm.add_item_to_workspace("i1", 0.1)
-        self.wm.add_item_to_workspace("i2", 0.2)
-        self.wm.add_item_to_workspace("i3", 0.3)
-        self.wm.add_item_to_workspace("i4", 0.05) # this should be in, replacing i1 if capacity was 3
-
-        # If capacity is 3, i1 (0.1) should have been replaced by i4 (0.05) because i4 was added last and i1 was least salient
-        # The current logic in ConcreteWM for store is: if full, call manage_workspace_capacity.
-        # manage_workspace_capacity removes least salient if new_item_salience is higher than it.
-        # Let's re-verify the logic.
-        # Setup: cap=3. items: (i1,0.1), (i2,0.2), (i3,0.3)
-        # Add (i4,0.4). i1 removed. items: (i2,0.2), (i3,0.3), (i4,0.4)
-        # Add (i5,0.05). wm is full. item with salience 0.2 (i2) is lowest. 0.05 < 0.2, so i5 NOT added.
-
+        # This test used self.wm which is now self.wm_no_bus. Adapting.
         # Reset for clear test of manage_capacity directly
-        self.wm = ConcreteWorkingMemoryModule(capacity=2)
-        id_a = self.wm.add_item_to_workspace("A", 0.5)
-        id_b = self.wm.add_item_to_workspace("B", 0.6)
-        id_c_fail = self.wm.add_item_to_workspace("C_fail", 0.1) # Fails as 0.1 < 0.5
+        wm_for_cap_test = ConcreteWorkingMemoryModule(capacity=2) # Local instance for this test
+        id_a = wm_for_cap_test.add_item_to_workspace("A", 0.5)
+        id_b = wm_for_cap_test.add_item_to_workspace("B", 0.6)
+        id_c_fail = wm_for_cap_test.add_item_to_workspace("C_fail", 0.1) # Fails as 0.1 < 0.5
         self.assertEqual(id_c_fail, "error_workspace_full")
 
         # Manually add a third item to exceed capacity for direct test
-        self.wm._workspace.append({'id': 'temp_c', 'content': 'C_direct', 'salience': 0.1})
-        self.assertEqual(len(self.wm._workspace), 3)
+        wm_for_cap_test._workspace.append({'id': 'temp_c', 'content': 'C_direct', 'salience': 0.1})
+        self.assertEqual(len(wm_for_cap_test._workspace), 3)
 
-        self.wm.manage_capacity() # Should remove 'temp_c' (salience 0.1)
+        wm_for_cap_test.manage_capacity() # Should remove 'temp_c' (salience 0.1)
 
-        contents = self.wm.get_workspace_contents()
+        contents = wm_for_cap_test.get_workspace_contents()
         self.assertEqual(len(contents), 2)
-        item_ids = [item['id'] for item in contents]
-        self.assertIn(id_a, item_ids)
-        self.assertIn(id_b, item_ids)
-        self.assertNotIn('temp_c', item_ids)
+        item_ids_cap_test = [item['id'] for item in contents]
+        self.assertIn(id_a, item_ids_cap_test)
+        self.assertIn(id_b, item_ids_cap_test)
+        self.assertNotIn('temp_c', item_ids_cap_test)
 
 
     def test_handle_forgetting_decay_salience(self):
-        id1 = self.wm.add_item_to_workspace("item_s1", salience=1.0)
-        id2 = self.wm.add_item_to_workspace("item_s2", salience=0.5)
+        id1 = self.wm_no_bus.add_item_to_workspace("item_s1", salience=1.0) # Using wm_no_bus
+        id2 = self.wm_no_bus.add_item_to_workspace("item_s2", salience=0.5) # Using wm_no_bus
 
-        self.wm.handle_forgetting(strategy='decay_salience')
+        self.wm_no_bus.handle_forgetting(strategy='decay_salience') # Using wm_no_bus
 
-        contents = self.wm.get_workspace_contents()
+        contents = self.wm_no_bus.get_workspace_contents() # Using wm_no_bus
         found_id1 = False
         for item in contents:
             if item['id'] == id1:
@@ -193,11 +271,11 @@ class TestConcreteWorkingMemoryModule(unittest.TestCase):
 
     def test_capacity_params_initialization(self):
         """Test that capacity_params is initialized correctly."""
-        self.assertTrue(hasattr(self.wm, 'capacity_params'))
-        self.assertIsInstance(self.wm.capacity_params, dict)
-        # setUp uses capacity=3 for self.wm
-        self.assertEqual(self.wm.capacity_params.get("max_items"), 3)
-        self.assertEqual(self.wm.capacity_params.get("max_item_complexity"), 5) # Default value
+        self.assertTrue(hasattr(self.wm_no_bus, 'capacity_params')) # Using wm_no_bus
+        self.assertIsInstance(self.wm_no_bus.capacity_params, dict)
+        # setUp uses capacity=3 for self.wm instances
+        self.assertEqual(self.wm_no_bus.capacity_params.get("max_items"), 3)
+        self.assertEqual(self.wm_no_bus.capacity_params.get("max_item_complexity"), 5) # Default value
 
         # Test with default capacity in constructor
         wm_default_cap = ConcreteWorkingMemoryModule() # Default capacity is 7
@@ -207,58 +285,61 @@ class TestConcreteWorkingMemoryModule(unittest.TestCase):
 
     def test_set_capacity_parameters(self):
         """Test setting capacity parameters."""
+        # Using wm_no_bus for this test as it's about the direct method call
         # Test setting valid parameters
         params1 = {"max_items": 20, "max_item_complexity": 10}
-        self.wm.set_capacity_parameters(params1)
-        self.assertEqual(self.wm.capacity_params["max_items"], 20)
-        self.assertEqual(self.wm.capacity_params["max_item_complexity"], 10)
+        self.wm_no_bus.set_capacity_parameters(params1)
+        self.assertEqual(self.wm_no_bus.capacity_params["max_items"], 20)
+        self.assertEqual(self.wm_no_bus.capacity_params["max_item_complexity"], 10)
 
         # Test setting only one parameter
         params2 = {"max_items": 15}
-        self.wm.set_capacity_parameters(params2)
-        self.assertEqual(self.wm.capacity_params["max_items"], 15)
-        self.assertEqual(self.wm.capacity_params["max_item_complexity"], 10) # Should retain previous value
+        self.wm_no_bus.set_capacity_parameters(params2)
+        self.assertEqual(self.wm_no_bus.capacity_params["max_items"], 15)
+        self.assertEqual(self.wm_no_bus.capacity_params["max_item_complexity"], 10) # Should retain previous value
 
         params3 = {"max_item_complexity": 7}
-        self.wm.set_capacity_parameters(params3)
-        self.assertEqual(self.wm.capacity_params["max_items"], 15) # Should retain previous value
-        self.assertEqual(self.wm.capacity_params["max_item_complexity"], 7)
+        self.wm_no_bus.set_capacity_parameters(params3)
+        self.assertEqual(self.wm_no_bus.capacity_params["max_items"], 15) # Should retain previous value
+        self.assertEqual(self.wm_no_bus.capacity_params["max_item_complexity"], 7)
 
         # Test with invalid values (should be ignored, values not updated)
-        initial_max_items = self.wm.capacity_params["max_items"]
-        initial_complexity = self.wm.capacity_params["max_item_complexity"]
+        initial_max_items = self.wm_no_bus.capacity_params["max_items"]
+        initial_complexity = self.wm_no_bus.capacity_params["max_item_complexity"]
 
-        self.wm.set_capacity_parameters({"max_items": -5}) # Negative value
-        self.assertEqual(self.wm.capacity_params["max_items"], initial_max_items)
+        self.wm_no_bus.set_capacity_parameters({"max_items": -5}) # Negative value
+        self.assertEqual(self.wm_no_bus.capacity_params["max_items"], initial_max_items)
 
-        self.wm.set_capacity_parameters({"max_item_complexity": "not_an_int"}) # Non-integer
-        self.assertEqual(self.wm.capacity_params["max_item_complexity"], initial_complexity)
+        self.wm_no_bus.set_capacity_parameters({"max_item_complexity": "not_an_int"}) # Non-integer
+        self.assertEqual(self.wm_no_bus.capacity_params["max_item_complexity"], initial_complexity)
 
-        self.wm.set_capacity_parameters({"max_items": 5.5}) # Float, should be ignored by current type check
-        self.assertEqual(self.wm.capacity_params["max_items"], initial_max_items)
+        self.wm_no_bus.set_capacity_parameters({"max_items": 5.5}) # Float, should be ignored
+        self.assertEqual(self.wm_no_bus.capacity_params["max_items"], initial_max_items)
 
 
         # Test with unknown parameter keys (should be ignored)
-        self.wm.set_capacity_parameters({"unknown_param": 100, "max_items": 25})
-        self.assertNotIn("unknown_param", self.wm.capacity_params)
-        self.assertEqual(self.wm.capacity_params["max_items"], 25) # Known param should update
+        self.wm_no_bus.set_capacity_parameters({"unknown_param": 100, "max_items": 25})
+        self.assertNotIn("unknown_param", self.wm_no_bus.capacity_params)
+        self.assertEqual(self.wm_no_bus.capacity_params["max_items"], 25) # Known param should update
 
         # Test with non-dict input
-        self.wm.set_capacity_parameters("not_a_dict") # Should print error, params not change
-        self.assertEqual(self.wm.capacity_params["max_items"], 25) # Check it didn't change from last valid set
+        self.wm_no_bus.set_capacity_parameters("not_a_dict") # Should print error, params not change
+        self.assertEqual(self.wm_no_bus.capacity_params["max_items"], 25) # Check it didn't change
 
 
     def test_get_capacity_parameters(self):
         """Test getting capacity parameters and that it returns a copy."""
-        current_params = self.wm.get_capacity_parameters()
-        self.assertEqual(current_params, self.wm.capacity_params)
+        # Using wm_no_bus
+        current_params = self.wm_no_bus.get_capacity_parameters()
+        self.assertEqual(current_params, self.wm_no_bus.capacity_params)
 
         # Modify the returned dictionary
         current_params["max_items"] = 1000
 
         # Ensure the internal dictionary is not affected
-        self.assertNotEqual(self.wm.capacity_params["max_items"], 1000)
-        self.assertEqual(self.wm.capacity_params["max_items"], 3) # Initial value from setUp
+        self.assertNotEqual(self.wm_no_bus.capacity_params["max_items"], 1000)
+        # Initial value from setUp for wm_no_bus (capacity=3)
+        self.assertEqual(self.wm_no_bus.capacity_params["max_items"], 3)
 
 
 if __name__ == '__main__':

--- a/PiaAGI_Research_Tools/PiaCML/tests/test_message_bus.py
+++ b/PiaAGI_Research_Tools/PiaCML/tests/test_message_bus.py
@@ -1,0 +1,179 @@
+import unittest
+from unittest.mock import MagicMock, call
+import datetime
+import uuid # Required for payload creation, though not directly for bus logic
+
+# Adjust path for consistent imports
+# This assumes tests are in PiaAGI_Research_Tools/PiaCML/tests/
+# and modules are in PiaAGI_Research_Tools/PiaCML/
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..')))
+
+try:
+    # Attempt to import directly from the package level due to __init__.py setup
+    from PiaAGI_Research_Tools.PiaCML import (
+        MessageBus,
+        GenericMessage,
+        PerceptDataPayload # Used in tests as an example payload
+    )
+except ModuleNotFoundError as e:
+    print(f"Package-level import error in test_message_bus.py: {e}")
+    print("Attempting direct local imports as fallback...")
+    # Fallback if the above doesn't work (e.g. when CWD is PiaAGI_Research_Tools/PiaCML/tests)
+    # This often means the test runner isn't picking up the package structure correctly.
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))) # Add PiaCML to path
+    from message_bus import MessageBus
+    from core_messages import GenericMessage, PerceptDataPayload
+
+
+class TestMessageBus(unittest.TestCase):
+
+    def setUp(self):
+        self.bus = MessageBus()
+        self.mock_callback_module1_typeA = MagicMock()
+        self.mock_callback_module2_typeA = MagicMock()
+        self.mock_callback_module1_typeB = MagicMock()
+        self._original_stdout = sys.stdout
+        # Suppress prints from the module during tests for cleaner output
+        # sys.stdout = open(os.devnull, 'w')
+
+    def tearDown(self):
+        """Restore stdout after each test."""
+        # sys.stdout.close()
+        sys.stdout = self._original_stdout
+
+
+    def test_subscribe_and_publish_single_subscriber(self):
+        self.bus.subscribe("module1", "TypeA", self.mock_callback_module1_typeA)
+
+        payload = PerceptDataPayload(modality="text", content="hello", source_timestamp=datetime.datetime.now(datetime.timezone.utc))
+        message = GenericMessage(source_module_id="perception", message_type="TypeA", payload=payload)
+
+        self.bus.publish(message)
+
+        self.mock_callback_module1_typeA.assert_called_once_with(message)
+
+    def test_publish_to_multiple_subscribers_same_type(self):
+        self.bus.subscribe("module1", "TypeA", self.mock_callback_module1_typeA)
+        self.bus.subscribe("module2", "TypeA", self.mock_callback_module2_typeA)
+
+        payload = {"data": "test data for TypeA"}
+        message = GenericMessage(source_module_id="source", message_type="TypeA", payload=payload)
+        self.bus.publish(message)
+
+        self.mock_callback_module1_typeA.assert_called_once_with(message)
+        self.mock_callback_module2_typeA.assert_called_once_with(message)
+
+    def test_publish_to_correct_message_type_subscribers_only(self):
+        self.bus.subscribe("module1", "TypeA", self.mock_callback_module1_typeA)
+        self.bus.subscribe("module1", "TypeB", self.mock_callback_module1_typeB)
+
+        payload_A = {"data": "TypeA data"}
+        message_A = GenericMessage(source_module_id="sourceA", message_type="TypeA", payload=payload_A)
+        self.bus.publish(message_A)
+
+        self.mock_callback_module1_typeA.assert_called_once_with(message_A)
+        self.mock_callback_module1_typeB.assert_not_called()
+
+        # Reset mock for next publish
+        self.mock_callback_module1_typeA.reset_mock()
+
+        payload_B = {"data": "TypeB data"}
+        message_B = GenericMessage(source_module_id="sourceB", message_type="TypeB", payload=payload_B)
+        self.bus.publish(message_B)
+
+        self.mock_callback_module1_typeA.assert_not_called()
+        self.mock_callback_module1_typeB.assert_called_once_with(message_B)
+
+    def test_publish_no_subscribers(self):
+        payload = {"data": "lonely data"}
+        message = GenericMessage(source_module_id="source", message_type="TypeC", payload=payload)
+        # No exception should be raised, and no callbacks called
+        try:
+            self.bus.publish(message)
+        except Exception as e:
+            self.fail(f"Publishing with no subscribers raised an exception: {e}")
+
+        self.mock_callback_module1_typeA.assert_not_called()
+        self.mock_callback_module2_typeA.assert_not_called()
+        self.mock_callback_module1_typeB.assert_not_called()
+
+    def test_unsubscribe(self):
+        self.bus.subscribe("module1", "TypeA", self.mock_callback_module1_typeA)
+        self.bus.unsubscribe("module1", "TypeA", self.mock_callback_module1_typeA)
+
+        payload = {"data": "data for unsubscribed"}
+        message = GenericMessage(source_module_id="source", message_type="TypeA", payload=payload)
+        self.bus.publish(message)
+
+        self.mock_callback_module1_typeA.assert_not_called()
+
+    def test_unsubscribe_specific_callback(self):
+        another_callback_for_module1 = MagicMock() # Different callback object
+        self.bus.subscribe("module1", "TypeA", self.mock_callback_module1_typeA)
+        self.bus.subscribe("module1", "TypeA", another_callback_for_module1)
+
+        self.bus.unsubscribe("module1", "TypeA", self.mock_callback_module1_typeA) # Unsubscribe only the first one
+
+        payload = {"data": "test for specific unsubscribe"}
+        message = GenericMessage(source_module_id="source", message_type="TypeA", payload=payload)
+        self.bus.publish(message)
+
+        self.mock_callback_module1_typeA.assert_not_called()
+        another_callback_for_module1.assert_called_once_with(message)
+
+        # Check that unsubscribing a non-existent callback or module doesn't error
+        self.bus.unsubscribe("module_unknown", "TypeA", MagicMock())
+        self.bus.unsubscribe("module1", "TypeUnknown", MagicMock())
+        self.bus.unsubscribe("module1", "TypeA", MagicMock()) # A callback that was never subscribed
+
+
+    def test_avoid_duplicate_subscriptions(self):
+        self.bus.subscribe("module1", "TypeA", self.mock_callback_module1_typeA)
+        self.bus.subscribe("module1", "TypeA", self.mock_callback_module1_typeA) # Attempt duplicate
+
+        self.assertEqual(len(self.bus.get_subscribers_for_type("TypeA")), 1)
+
+        payload = {"data": "test for duplicate avoidance"}
+        message = GenericMessage(source_module_id="source", message_type="TypeA", payload=payload)
+        self.bus.publish(message)
+        self.mock_callback_module1_typeA.assert_called_once() # Should only be called once
+
+    def test_get_subscribers_for_type(self):
+        self.assertEqual(len(self.bus.get_subscribers_for_type("TypeNonExistent")), 0)
+
+        self.bus.subscribe("module1", "TypeX", self.mock_callback_module1_typeA)
+        subscribers = self.bus.get_subscribers_for_type("TypeX")
+        self.assertEqual(len(subscribers), 1)
+        self.assertEqual(subscribers[0][0], "module1") # module_id
+        self.assertEqual(subscribers[0][1], self.mock_callback_module1_typeA) # callback
+
+        # Ensure it returns a copy
+        subscribers_copy = self.bus.get_subscribers_for_type("TypeX")
+        subscribers_copy.append(("fake_module", MagicMock()))
+        self.assertEqual(len(self.bus.get_subscribers_for_type("TypeX")), 1) # Original should be unchanged
+
+
+    def test_callback_exception_handling(self):
+        faulty_callback = MagicMock(side_effect=Exception("Callback error!"))
+        self.bus.subscribe("faulty_module", "TypeA", faulty_callback)
+        self.bus.subscribe("module1", "TypeA", self.mock_callback_module1_typeA) # Good callback
+
+        payload = {"data": "test data for exception"}
+        message = GenericMessage(source_module_id="source", message_type="TypeA", payload=payload)
+
+        # The bus publish method should catch the exception from faulty_callback
+        # and still proceed to call other subscribers.
+        # For this test, we primarily ensure the good callback is still invoked.
+        # A more advanced test might involve capturing stdout/stderr if the bus prints errors.
+        try:
+            self.bus.publish(message)
+        except Exception as e:
+            self.fail(f"MessageBus.publish() raised an unexpected exception: {e}")
+
+        faulty_callback.assert_called_once_with(message)
+        self.mock_callback_module1_typeA.assert_called_once_with(message) # Ensure other callbacks are not affected
+
+if __name__ == '__main__':
+    unittest.main(argv=['first-arg-is-ignored'], exit=False)

--- a/ToDoList.md
+++ b/ToDoList.md
@@ -183,7 +183,8 @@ This section outlines proposed future development directions for the PiaAGI Rese
 - [x] **Prototype Advanced LTM (Phase 1):** Implement foundational aspects of a richer LTM structure (e.g., basic graph representation for semantic LTM or structured episodic entries) based on the `PiaCML_Advanced_Roadmap.md`. (Completed on 2024-03-08 by Jules)
 - [x] **Prototype Advanced Motivational System (Phase 1):** Implement a computational model for one intrinsic motivation (e.g., curiosity) based on the `PiaCML_Advanced_Roadmap.md`. (Completed on 2024-03-08 by Jules)
 - [x] **Prototype Advanced Emotion Module (Phase 1):** Implement enhanced appraisal mechanisms based on the `PiaCML_Advanced_Roadmap.md`. (Completed on 2024-03-08 by Jules)
-- [x] **Implement Core Inter-Module Communication System:** Develop a basic version of the message-passing system defined in `PiaCML_InterModule_Communication.md`, supporting 2-3 key message types. (Data structures implemented) (Completed on 2024-03-08 by Jules)
+- [x] **Implement Core Inter-Module Communication System (Phase 1 - Basic Bus & Data Structures):** Defined core message data structures and implemented a basic synchronous in-memory Message Bus with subscribe/publish capabilities. (Completed on 2024-03-08 by Jules)
+- [ ] **Implement Core Inter-Module Communication System (Phase 2 - Advanced Bus Features & Full Module Integration):** Enhance Message Bus (e.g., with asynchronous capabilities, improved error handling, filtering options) and integrate it thoroughly with all relevant CML modules, replacing direct calls where appropriate.
 - [x] **Proof-of-Concept for an Architectural Maturation Hook:** Implement a basic mechanism for one of the conceptualized hooks (e.g., dynamic WM capacity adjustment) in a relevant module prototype. (Completed on 2024-03-08 by Jules)
 
 ### PiaSE (PiaAGI Simulation Environment) - Enhancements


### PR DESCRIPTION
This commit introduces Phase 1 of the core inter-module communication system for PiaCML.

Key changes:
- I created `PiaAGI_Research_Tools/PiaCML/message_bus.py` which defines a basic synchronous, in-memory `MessageBus` class. This bus supports subscribing modules to specific message types and publishing `GenericMessage` instances to the appropriate subscribers. It includes basic error handling for callbacks and avoids duplicate subscriptions.
- I added comprehensive unit tests for the `MessageBus` in `PiaAGI_Research_Tools/PiaCML/tests/test_message_bus.py`.
- I updated `PiaAGI_Research_Tools/PiaCML/__init__.py` to expose the `MessageBus` class.

Conceptual Integration:
- I modified `ConcretePerceptionModule` to optionally accept a `MessageBus` instance and include a method (`process_and_publish_stimulus`) to demonstrate publishing a `GenericMessage` with a `PerceptDataPayload`.
- I modified `ConcreteWorkingMemoryModule` to optionally accept a `MessageBus` instance, subscribe to "PerceptData" messages upon initialization, and include a callback handler (`handle_percept_data_message`).
- I updated unit tests for both `ConcretePerceptionModule` and `ConcreteWorkingMemoryModule` to test these new message bus interactions.

The `ToDoList.md` has been updated to reflect the completion of Phase 1 for the communication system and to add a task for Phase 2 (advanced bus features and full module integration).