### PR TITLE
feat(PiaCML): Integrate Message Bus with Self-Model Module

### DIFF
--- a/PiaAGI_Research_Tools/PiaCML/__init__.py
+++ b/PiaAGI_Research_Tools/PiaCML/__init__.py
@@ -8,7 +8,8 @@ from .core_messages import (
     MemoryItem,
     PerceptDataPayload,
     GoalUpdatePayload,
-    LTMQueryResultPayload
+    LTMQueryResultPayload,
+    SelfKnowledgeConfidenceUpdatePayload # Added
     # Add other specific payloads here as they are defined and needed for top-level access
 )
 
@@ -33,7 +34,7 @@ from .concrete_motivational_system_module import ConcreteMotivationalSystemModul
 
 # Optional: Define __all__ if you want to control `from PiaAGI_Research_Tools.PiaCML import *`
 __all__ = [
-    "GenericMessage", "MemoryItem", "PerceptDataPayload", "GoalUpdatePayload", "LTMQueryResultPayload",
+    "GenericMessage", "MemoryItem", "PerceptDataPayload", "GoalUpdatePayload", "LTMQueryResultPayload", "SelfKnowledgeConfidenceUpdatePayload", # Added
     "MessageBus",
     "BaseMemoryModule", "BaseLongTermMemoryModule", "BaseWorkingMemoryModule",
     "BaseEmotionModule", "BaseMotivationalSystemModule",

--- a/PiaAGI_Research_Tools/PiaCML/core_messages.py
+++ b/PiaAGI_Research_Tools/PiaCML/core_messages.py
@@ -69,6 +69,19 @@ class LTMQueryResultPayload:
     error_message: Optional[str] = None # Description of error if success_status is False
     metadata: Dict[str, Any] = field(default_factory=dict) # E.g., number of results, confidence
 
+@dataclass
+class SelfKnowledgeConfidenceUpdatePayload:
+    """
+    Payload for the Self-Model to communicate updates to its confidence
+    in a particular piece of knowledge or a capability.
+    """
+    item_id: str  # ID of the knowledge concept, skill, or tool
+    item_type: str  # e.g., "knowledge", "capability"
+    new_confidence: float  # The updated confidence score (e.g., 0.0 to 1.0)
+    previous_confidence: Optional[float] = None # Optional: good for logging change
+    source_of_update: Optional[str] = None # E.g., "task_success", "user_feedback", "learning_event"
+
+
 # Example LTMQueryPayload (not explicitly requested to be created in this file by the prompt,
 # but useful for context with LTMQueryResultPayload).
 # If needed, it would be defined here as well.
@@ -156,5 +169,16 @@ if __name__ == '__main__':
     print(ltm_res1)
     assert len(ltm_res1.results) == 2
     assert ltm_res1.results[0].content == "Result for LTM query"
+
+    # Test SelfKnowledgeConfidenceUpdatePayload
+    skcup1 = SelfKnowledgeConfidenceUpdatePayload(
+        item_id="concept_gravity",
+        item_type="knowledge",
+        new_confidence=0.95,
+        previous_confidence=0.90,
+        source_of_update="successful_experiment"
+    )
+    print(skcup1)
+    assert skcup1.new_confidence == 0.95
 
     print("\nCore messages example usage complete.")

--- a/ToDoList.md
+++ b/ToDoList.md
@@ -192,6 +192,7 @@ This section outlines proposed future development directions for the PiaAGI Rese
     - [x] Integrated Message Bus with `ConcreteWorkingMemoryModule` to subscribe to "PerceptData" messages. (Completed on 2024-03-08 by Jules)
     - [x] Integrated Message Bus with `ConcreteLongTermMemoryModule` for handling "LTMQuery" messages and publishing "LTMQueryResult" messages. (Completed on 2024-03-08 by Jules)
     - [x] Integrated Message Bus with `ConcreteMotivationalSystemModule` for publishing "GoalUpdate" messages. (Completed on 2024-03-08 by Jules)
+    - [x] Integrated Message Bus with `ConcreteSelfModelModule` to publish "SelfKnowledgeConfidenceUpdate" and subscribe to "GoalUpdate" messages. (Completed on 2024-03-08 by Jules)
 - [x] **Proof-of-Concept for an Architectural Maturation Hook:** Implement a basic mechanism for one of the conceptualized hooks (e.g., dynamic WM capacity adjustment) in a relevant module prototype. (Completed on 2024-03-08 by Jules)
 
 ### PiaSE (PiaAGI Simulation Environment) - Enhancements


### PR DESCRIPTION
This commit integrates the MessageBus with the ConcreteSelfModelModule, enabling it to publish its own state changes and subscribe to relevant messages from other modules.

Key changes:

1.  **Core Messages (`core_messages.py`, `__init__.py`):**
    *   Added `SelfKnowledgeConfidenceUpdatePayload` dataclass to represent
        updates to my confidence in knowledge or capabilities.
    *   Exported the new payload type from the package.

2.  **ConcreteSelfModelModule:**
    *   Updated to accept an optional `MessageBus` instance.
    *   The `update_confidence` method now publishes a
        `SelfKnowledgeConfidenceUpdate` message via the bus if a bus
        is configured. The message includes item ID, type, new confidence,
        previous confidence, and source of update.
    *   Subscribes to "GoalUpdate" messages upon initialization if a bus is
        present.
    *   Added `handle_goal_update_message` callback to conceptually process
        these updates (currently stores them for later use/testing).

3.  **Tests (`test_concrete_self_model_module.py`):**
    *   Updated test setup to handle SMM instances with and without a
        message bus (real and mock).
    *   Added tests to verify the publication of
        `SelfKnowledgeConfidenceUpdate` messages.
    *   Added tests to verify that the module subscribes to and correctly
        handles "GoalUpdate" messages.

The `ToDoList.md` has been updated to reflect this integration as part of the ongoing Phase 2 development of the communication system.