### PR TITLE
feat(PiaCML): Define new messages & integrate Bus with Attention & To…

### DIFF
--- a/PiaAGI_Research_Tools/PiaCML/__init__.py
+++ b/PiaAGI_Research_Tools/PiaCML/__init__.py
@@ -11,7 +11,9 @@ from .core_messages import (
     LTMQueryResultPayload,
     SelfKnowledgeConfidenceUpdatePayload, # Added
     LTMQueryPayload,                    # Added
-    ActionCommandPayload                # Added
+    ActionCommandPayload,               # Added
+    AttentionFocusUpdatePayload,        # Added
+    ToMInferenceUpdatePayload           # Added
     # Add other specific payloads here as they are defined and needed for top-level access
 )
 
@@ -38,7 +40,8 @@ from .concrete_motivational_system_module import ConcreteMotivationalSystemModul
 __all__ = [
     "GenericMessage", "MemoryItem", "PerceptDataPayload", "GoalUpdatePayload",
     "LTMQueryResultPayload", "SelfKnowledgeConfidenceUpdatePayload",
-    "LTMQueryPayload", "ActionCommandPayload", # Added
+    "LTMQueryPayload", "ActionCommandPayload",
+    "AttentionFocusUpdatePayload", "ToMInferenceUpdatePayload", # Added
     "MessageBus",
     "BaseMemoryModule", "BaseLongTermMemoryModule", "BaseWorkingMemoryModule",
     "BaseEmotionModule", "BaseMotivationalSystemModule",

--- a/PiaAGI_Research_Tools/PiaCML/concrete_attention_module.py
+++ b/PiaAGI_Research_Tools/PiaCML/concrete_attention_module.py
@@ -1,178 +1,296 @@
-from abc import ABC, abstractmethod # Keep for BaseAttentionModule import if it also imports them
 from typing import Any, List, Dict, Optional
+import datetime # Added for AttentionFocusUpdatePayload timestamp
 
 try:
     from .base_attention_module import BaseAttentionModule
+    from .message_bus import MessageBus
+    from .core_messages import GenericMessage, GoalUpdatePayload, AttentionFocusUpdatePayload
+    # Assuming EmotionalStateChangePayload will be handled as a Dict for now if not formally defined in core_messages
 except ImportError:
-    # Fallback for scenarios where the relative import might fail
     from base_attention_module import BaseAttentionModule
+    try:
+        from message_bus import MessageBus
+        from core_messages import GenericMessage, GoalUpdatePayload, AttentionFocusUpdatePayload
+    except ImportError:
+        MessageBus = None # type: ignore
+        GenericMessage = None # type: ignore
+        GoalUpdatePayload = None # type: ignore
+        AttentionFocusUpdatePayload = None # type: ignore
+        # EmotionalStateChangePayload would also be None or a placeholder if imported
 
 class ConcreteAttentionModule(BaseAttentionModule):
     """
     A concrete implementation of the BaseAttentionModule.
-    This implementation uses a simple dictionary to store the current attentional focus
-    and applies basic rule-based filtering and load management.
+    Manages current attentional focus, can publish focus updates,
+    and subscribe to GoalUpdate and EmotionalStateChange messages to modulate attention.
     """
-    def __init__(self):
-        self._current_focus: Optional[Any] = None
-        self._current_priority: float = 0.0
-        self._active_filters: List[Dict[str, Any]] = []
-        self._cognitive_load_level: float = 0.0
-        print("ConcreteAttentionModule initialized.")
+    def __init__(self, message_bus: Optional[MessageBus] = None):
+        """
+        Initializes the ConcreteAttentionModule.
 
-    def direct_attention(self, focus_target: Any, priority: float, context: Dict[str, Any] = None) -> bool:
-        """Directs attention to a new target if priority is high enough or focus is None."""
-        print(f"ConcreteAttentionModule: Attempting to direct attention to '{focus_target}' with priority {priority}.")
+        Args:
+            message_bus: An optional instance of MessageBus for communication.
+        """
+        self.current_focus: Optional[AttentionFocusUpdatePayload] = None
+        self._active_filters: List[Dict[str, Any]] = [] # Kept from original for filter_information method
+        self._cognitive_load_level: float = 0.0 # Kept from original
 
-        if context:
-            if context.get('clear_filters'):
-                self._active_filters = []
-                print("ConcreteAttentionModule: Cleared active filters due to context.")
-            if 'add_filter' in context and isinstance(context['add_filter'], dict):
-                self._active_filters.append(context['add_filter'])
-                print(f"ConcreteAttentionModule: Added filter: {context['add_filter']}.")
+        self.message_bus = message_bus
+        self.handled_goal_updates_for_attention: List[GoalUpdatePayload] = []
+        self.handled_emotion_updates_for_attention: List[Dict] = [] # Assuming dict for EmotionalStateChangePayload
 
-        # Simple logic: always shift if new priority is higher, or if no current focus.
-        if self._current_focus is None or priority >= self._current_priority:
-            self._current_focus = focus_target
-            self._current_priority = priority
-            print(f"ConcreteAttentionModule: Attention directed to '{self._current_focus}' with priority {self._current_priority}.")
-            return True
-        print(f"ConcreteAttentionModule: Attention NOT shifted. Current focus '{self._current_focus}' (priority {self._current_priority}) retained.")
-        return False
+        bus_status_msg = "not configured"
+        if self.message_bus:
+            if GenericMessage and GoalUpdatePayload and AttentionFocusUpdatePayload: # Check core imports
+                try:
+                    self.message_bus.subscribe(
+                        module_id="ConcreteAttentionModule_01", # Example ID
+                        message_type="GoalUpdate",
+                        callback=self.handle_goal_update_for_attention
+                    )
+                    self.message_bus.subscribe(
+                        module_id="ConcreteAttentionModule_01",
+                        message_type="EmotionalStateChange", # Assuming this is the message type string
+                        callback=self.handle_emotion_update_for_attention
+                    )
+                    bus_status_msg = "configured and subscribed to GoalUpdate & EmotionalStateChange"
+                except Exception as e:
+                    bus_status_msg = f"configured but FAILED to subscribe: {e}"
+            else:
+                bus_status_msg = "configured but core message types for subscription not available"
 
-    def filter_information(self, information_stream: List[Dict[str, Any]], current_focus: Any = None) -> List[Dict[str, Any]]:
-        """Filters information based on a simple relevance check to the current focus (if any) and then applies active filters."""
-        effective_focus = current_focus if current_focus is not None else self._current_focus
-        print(f"ConcreteAttentionModule: Filtering {len(information_stream)} items based on focus: '{effective_focus}'. Active filters: {self._active_filters}")
+        print(f"ConcreteAttentionModule initialized. Message bus {bus_status_msg}.")
 
-        # Initial focus-based filtering
-        if effective_focus:
+    def set_attention_focus(self, item_id: Optional[str], focus_type: str, intensity: float, source_trigger_id: Optional[str] = None) -> bool:
+        """
+        Sets the current attentional focus and publishes an update.
+        The priority logic from the old direct_attention is removed; this method now directly sets the focus.
+        Callers are responsible for deciding if a focus shift is warranted.
+        """
+        if not (AttentionFocusUpdatePayload and GenericMessage): # Check imports
+            print("Error: AttentionFocusUpdatePayload or GenericMessage not available. Cannot set focus or publish.")
+            return False
+
+        clamped_intensity = max(0.0, min(1.0, intensity))
+        self.current_focus = AttentionFocusUpdatePayload(
+            focused_item_id=item_id,
+            focus_type=focus_type,
+            intensity=clamped_intensity,
+            source_trigger_message_id=source_trigger_id
+            # timestamp is handled by default_factory
+        )
+        print(f"ConcreteAttentionModule: Attention focus set to '{item_id}' (Type: {focus_type}, Intensity: {clamped_intensity:.2f}).")
+
+        if self.message_bus:
+            message = GenericMessage(
+                source_module_id="ConcreteAttentionModule_01", # Example ID
+                message_type="AttentionFocusUpdate",
+                payload=self.current_focus
+            )
+            try:
+                self.message_bus.publish(message)
+                print(f"ConcreteAttentionModule: Published AttentionFocusUpdate for '{item_id}'.")
+            except Exception as e:
+                print(f"ConcreteAttentionModule: Error publishing AttentionFocusUpdate: {e}")
+        return True
+
+    def handle_goal_update_for_attention(self, message: GenericMessage):
+        """Handles GoalUpdate messages to potentially shift attention."""
+        if GoalUpdatePayload and isinstance(message.payload, GoalUpdatePayload):
+            payload: GoalUpdatePayload = message.payload
+            self.handled_goal_updates_for_attention.append(payload)
+            # print(f"AttentionModule: Received GoalUpdate for {payload.goal_id}, Priority: {payload.priority}, Status: {payload.status}") # Optional
+
+            # Example: High priority active goals grab attention
+            if payload.priority > 0.7 and payload.status in ["new", "active", "PENDING", "ACTIVE", "updated"]:
+                # print(f"  AttentionModule: High priority goal {payload.goal_id} detected. Shifting attention.")
+                self.set_attention_focus(
+                    item_id=f"goal_{payload.goal_id}",
+                    focus_type="goal_directed_trigger",
+                    intensity=payload.priority, # Use goal priority as attention intensity (scaled 0-1 if needed)
+                    source_trigger_id=message.message_id
+                )
+        else:
+            print(f"AttentionModule received GoalUpdate with unexpected payload type: {type(message.payload)}")
+
+    def handle_emotion_update_for_attention(self, message: GenericMessage):
+        """Handles EmotionalStateChange messages to potentially modulate attention."""
+        # Assuming EmotionalStateChangePayload is a dict for now, as per prompt.
+        # Replace with `isinstance(message.payload, EmotionalStateChangePayload)` if defined.
+        if isinstance(message.payload, dict) and "valence" in message.payload and "arousal" in message.payload:
+            payload: dict = message.payload
+            self.handled_emotion_updates_for_attention.append(payload)
+            # print(f"AttentionModule: Received EmotionalStateChange: V={payload.get('valence')}, A={payload.get('arousal')}") # Optional
+
+            arousal = payload.get("arousal", 0.0)
+            if arousal > 0.7: # Example: High arousal intensifies focus
+                # print(f"  AttentionModule: High arousal ({arousal:.2f}) detected. Conceptually intensifying current focus.")
+                current_item_id = self.current_focus.focused_item_id if self.current_focus else "general_environment_due_to_high_arousal"
+                current_intensity = self.current_focus.intensity if self.current_focus else 0.3 # Base intensity if no prior focus
+
+                self.set_attention_focus(
+                    item_id=current_item_id,
+                    focus_type="emotion_triggered_intensity_increase",
+                    intensity=min(1.0, current_intensity + 0.1 + (arousal - 0.7)*0.5), # Increase intensity based on arousal
+                    source_trigger_id=message.message_id
+                )
+            elif arousal < 0.2 and self.current_focus and self.current_focus.focus_type == "emotion_triggered_intensity_increase":
+                # Example: If arousal drops significantly, and current focus was due to emotion, maybe reduce intensity
+                # print(f"  AttentionModule: Low arousal ({arousal:.2f}) detected. Reducing intensity of emotion-triggered focus.")
+                self.set_attention_focus(
+                    item_id=self.current_focus.focused_item_id,
+                    focus_type=self.current_focus.focus_type, # Keep type or change to "relaxed"
+                    intensity=max(0.1, self.current_focus.intensity * 0.7), # Reduce intensity
+                    source_trigger_id=message.message_id
+                )
+        else:
+            print(f"AttentionModule received EmotionalStateChange with unexpected payload structure: {type(message.payload)}")
+
+
+    def filter_information(self, information_stream: List[Dict[str, Any]], current_focus_override: Optional[Any] = None) -> List[Dict[str, Any]]:
+        """Filters information based on current focus (or override) and active filters."""
+        # Use focused_item_id from self.current_focus if it's set
+        effective_focus_target = None
+        if current_focus_override is not None:
+            effective_focus_target = current_focus_override
+        elif self.current_focus and self.current_focus.focused_item_id is not None:
+            effective_focus_target = self.current_focus.focused_item_id
+
+        # print(f"ConcreteAttentionModule: Filtering {len(information_stream)} items. Effective focus target: '{effective_focus_target}'. Active filters: {self._active_filters}")
+
+        if effective_focus_target:
             focused_stream = []
             for item in information_stream:
                 is_relevant = False
-                if isinstance(effective_focus, str):
-                    if 'tags' in item and isinstance(item['tags'], list) and effective_focus in item['tags']:
+                # Assuming effective_focus_target is a string ID
+                if isinstance(effective_focus_target, str):
+                    if 'tags' in item and isinstance(item['tags'], list) and effective_focus_target in item['tags']:
                         is_relevant = True
-                    elif 'content' in item and isinstance(item['content'], str) and effective_focus in item['content']:
+                    elif 'content' in item and isinstance(item['content'], str) and effective_focus_target in item['content']: # Simple string match
                         is_relevant = True
-                    elif item.get('id') == effective_focus:
+                    elif item.get('id') == effective_focus_target:
                         is_relevant = True
                 if is_relevant:
                     focused_stream.append(item)
         else:
-            focused_stream = list(information_stream) # Work on a copy if no focus filtering
+            focused_stream = list(information_stream)
 
-        # Apply active filters progressively
+        # Apply active filters if any (original logic largely kept)
         if not self._active_filters:
-            print(f"ConcreteAttentionModule: No active filters. Filtered stream (by focus only) contains {len(focused_stream)} items.")
+            # print(f"ConcreteAttentionModule: No active filters. Filtered stream (by focus only) contains {len(focused_stream)} items.")
             return focused_stream
 
-        stream_after_active_filters = list(focused_stream) # Start with focus-filtered (or all if no focus)
-        for f_idx, active_filter in enumerate(self._active_filters):
-            print(f"ConcreteAttentionModule: Applying filter {f_idx + 1}/{len(self._active_filters)}: {active_filter}")
+        stream_after_active_filters = list(focused_stream)
+        for active_filter in self._active_filters: # Removed f_idx for simplicity
+            # print(f"ConcreteAttentionModule: Applying filter: {active_filter}")
             next_filtered_stream = []
             filter_type = active_filter.get('type')
             filter_key = active_filter.get('key')
-
             for item in stream_after_active_filters:
                 passes_filter = False
-                if filter_type == 'value_equals':
-                    filter_value = active_filter.get('value')
-                    if item.get(filter_key) == filter_value:
-                        passes_filter = True
-                elif filter_type == 'value_gt':
-                    filter_threshold = active_filter.get('threshold')
-                    if item.get(filter_key, 0) > filter_threshold:
-                        passes_filter = True
-                elif filter_type == 'tag_present':
-                    filter_tag = active_filter.get('tag')
-                    if filter_tag in item.get('tags', []):
-                        passes_filter = True
-                else:
-                    # If filter type is unknown or not implemented, item passes by default
-                    # Or, you could choose to make it fail: passes_filter = False
-                    print(f"ConcreteAttentionModule: Unknown filter type '{filter_type}', item passes by default.")
-                    passes_filter = True
+                if filter_type == 'value_equals' and item.get(filter_key) == active_filter.get('value'): passes_filter = True
+                elif filter_type == 'value_gt' and item.get(filter_key, 0) > active_filter.get('threshold'): passes_filter = True
+                elif filter_type == 'tag_present' and active_filter.get('tag') in item.get('tags', []): passes_filter = True
+                elif not filter_type : passes_filter = True # No specific type, pass all? Or make it strict? For PoC, pass.
+                else: print(f"ConcreteAttentionModule: Unknown or unhandled filter type '{filter_type}'.") # Passes by default
 
-                if passes_filter:
-                    next_filtered_stream.append(item)
+                if passes_filter: next_filtered_stream.append(item)
             stream_after_active_filters = next_filtered_stream
-            print(f"ConcreteAttentionModule: Stream size after filter {active_filter}: {len(stream_after_active_filters)}")
-
-        print(f"ConcreteAttentionModule: Filtered stream (focus + active filters) contains {len(stream_after_active_filters)} items.")
+        # print(f"ConcreteAttentionModule: Filtered stream (focus + active filters) contains {len(stream_after_active_filters)} items.")
         return stream_after_active_filters
 
     def manage_cognitive_load(self, current_load: float, capacity_thresholds: Dict[str, float]) -> Dict[str, Any]:
         """Manages cognitive load by adjusting internal state or suggesting actions."""
         self._cognitive_load_level = current_load
-        print(f"ConcreteAttentionModule: Managing cognitive load. Current: {current_load}, Thresholds: {capacity_thresholds}")
-
+        # print(f"ConcreteAttentionModule: Managing cognitive load. Current: {current_load}, Thresholds: {capacity_thresholds}")
         action_taken = {'action': 'none', 'details': 'Load within acceptable limits.'}
-
         if current_load >= capacity_thresholds.get('overload', 0.9):
-            action_taken = {'action': 'reduce_focus_strictness', 'details': 'Cognitive overload detected. Suggested narrowing attention or reducing task parallelism.'}
-            # Example: self._active_filters.append('strict_filtering_on_overload')
-            print(f"ConcreteAttentionModule: Overload detected. Action: {action_taken}")
+            action_taken = {'action': 'reduce_focus_strictness', 'details': 'Cognitive overload.'}
         elif current_load >= capacity_thresholds.get('optimal', 0.7):
-            action_taken = {'action': 'maintain_focus', 'details': 'Optimal load. Maintaining current attention strategy.'}
-            print(f"ConcreteAttentionModule: Optimal load. Action: {action_taken}")
-
+            action_taken = {'action': 'maintain_focus', 'details': 'Optimal load.'}
         return action_taken
 
     def get_attentional_state(self) -> Dict[str, Any]:
         """Returns the current attentional state."""
-        state = {
-            'current_focus': self._current_focus,
-            'current_priority': self._current_priority,
-            'active_filters': list(self._active_filters), # Return a copy
+        return {
+            'current_focus_payload': self.current_focus.__dict__ if self.current_focus else None,
+            'active_filters_count': len(self._active_filters), # Simplified from full list
             'cognitive_load_level': self._cognitive_load_level,
             'module_type': 'ConcreteAttentionModule'
         }
-        print(f"ConcreteAttentionModule: Returning state: {state}")
-        return state
+
+    # BaseAttentionModule compatibility for direct_attention if needed by other old code
+    # This now calls the new set_attention_focus method.
+    def direct_attention(self, focus_target: Any, priority: float, context: Dict[str, Any] = None) -> bool:
+        """
+        Compatibility method for BaseAttentionModule's direct_attention.
+        Focuses attention based on a target and priority, mapping to new set_attention_focus.
+        """
+        # print(f"ConcreteAttentionModule: `direct_attention` called for '{focus_target}' with priority {priority}.")
+        focus_type = (context.get("type", "direct_call") if context else "direct_call")
+        item_id = str(focus_target) if not isinstance(focus_target, str) else focus_target
+
+        # The old direct_attention had logic to only shift if priority was higher.
+        # The new set_attention_focus always sets and publishes.
+        # For compatibility, we can decide if we want to retain the priority check here.
+        # For this PoC, let's assume direct_attention implies an override or important update.
+        return self.set_attention_focus(item_id=item_id, focus_type=focus_type, intensity=priority, source_trigger_id=context.get("source_message_id") if context else None)
+
 
 if __name__ == '__main__':
-    attention_module = ConcreteAttentionModule()
+    # Example with MessageBus
+    bus = MessageBus() if MessageBus else None
+    attention_module = ConcreteAttentionModule(message_bus=bus)
 
-    # Initial state
-    print("\n--- Initial State ---")
+    print("\n--- Initial State (with Bus) ---")
     print(attention_module.get_attentional_state())
 
-    # Direct attention
-    print("\n--- Directing Attention ---")
-    attention_module.direct_attention(focus_target="ProjectAlpha", priority=0.8, context={'type': 'top-down'})
+    print("\n--- Setting Attention Focus (will publish if bus) ---")
+    attention_module.set_attention_focus(item_id="goal_alpha", focus_type="goal_directed", intensity=0.8, source_trigger_id="msg_goal_init")
     print(attention_module.get_attentional_state())
-    attention_module.direct_attention(focus_target="UrgentTaskOmega", priority=0.7) # Lower priority
-    print(attention_module.get_attentional_state()) # Should not change
-    attention_module.direct_attention(focus_target="UrgentTaskOmega", priority=0.9) # Higher priority
-    print(attention_module.get_attentional_state()) # Should change
 
-    # Filter information
-    print("\n--- Filtering Information ---")
-    stream = [
-        {'id': 'item1', 'content': "Details about ProjectAlpha.", 'tags': ["ProjectAlpha", "research"]},
-        {'id': 'item2', 'content': "Random information.", 'tags': ["general"]},
-        {'id': 'item3', 'content': "Update on UrgentTaskOmega.", 'tags': ["UrgentTaskOmega", "critical"]},
-        {'id': 'item4', 'content': "Another detail for ProjectAlpha research.", 'tags': ["ProjectAlpha"]},
-    ]
-    # Focus is "UrgentTaskOmega"
-    filtered = attention_module.filter_information(stream)
-    print("Filtered items (focus UrgentTaskOmega):", [item['id'] for item in filtered])
+    if bus and GoalUpdatePayload and GenericMessage: # Check imports
+        # Simulate receiving a high-priority goal update
+        print("\n--- Simulating GoalUpdate Message Reception ---")
+        mock_goal_payload = GoalUpdatePayload(
+            goal_id="super_urgent_goal",
+            goal_description="Defuse the situation immediately!",
+            priority=0.95, # High priority
+            status="ACTIVE",
+            originator="CrisisSystem"
+        )
+        goal_message = GenericMessage(
+            source_module_id="CrisisSystem",
+            message_type="GoalUpdate",
+            payload=mock_goal_payload,
+            message_id="crisis_msg_001"
+        )
+        # Manually call handler or publish if bus is real (for __main__ test, direct call is fine)
+        # attention_module.handle_goal_update_for_attention(goal_message)
+        bus.publish(goal_message) # Publish to the bus the module is subscribed to
 
-    # Filter with explicit focus override
-    filtered_override = attention_module.filter_information(stream, current_focus="ProjectAlpha")
-    print("Filtered items (focus ProjectAlpha override):", [item['id'] for item in filtered_override])
+        print("State after high-priority goal update:")
+        final_state = attention_module.get_attentional_state()
+        print(final_state)
+        assert final_state['current_focus_payload']['focused_item_id'] == "goal_super_urgent_goal"
+        assert final_state['current_focus_payload']['intensity'] == 0.95
 
-
-    # Manage cognitive load
-    print("\n--- Managing Cognitive Load ---")
-    thresholds = {'optimal': 0.6, 'overload': 0.85}
-    print(attention_module.manage_cognitive_load(current_load=0.5, capacity_thresholds=thresholds))
-    print(attention_module.get_attentional_state())
-    print(attention_module.manage_cognitive_load(current_load=0.75, capacity_thresholds=thresholds)) # Optimal
-    print(attention_module.get_attentational_state())
-    print(attention_module.manage_cognitive_load(current_load=0.9, capacity_thresholds=thresholds)) # Overload
-    print(attention_module.get_attentional_state())
+        # Simulate high arousal emotion
+        print("\n--- Simulating EmotionalStateChange Message Reception ---")
+        mock_emotion_payload = {"valence": -0.5, "arousal": 0.85, "dominance": -0.3} # High arousal
+        emotion_message = GenericMessage(
+            source_module_id="EmotionModule",
+            message_type="EmotionalStateChange",
+            payload=mock_emotion_payload,
+            message_id="emotion_flare_002"
+        )
+        bus.publish(emotion_message)
+        print("State after high arousal emotion update:")
+        final_state_after_emotion = attention_module.get_attentional_state()
+        print(final_state_after_emotion)
+        # Intensity should have increased from the emotion trigger
+        # Initial: 0.95. After emotion: min(1.0, 0.95 + 0.1 + (0.85-0.7)*0.5) = min(1.0, 0.95 + 0.1 + 0.075) = min(1.0, 1.125) = 1.0
+        assert final_state_after_emotion['current_focus_payload']['intensity'] == 1.0
+        assert final_state_after_emotion['current_focus_payload']['focus_type'] == "emotion_triggered_intensity_increase"
 
     print("\nExample Usage Complete.")

--- a/PiaAGI_Research_Tools/PiaCML/core_messages.py
+++ b/PiaAGI_Research_Tools/PiaCML/core_messages.py
@@ -107,6 +107,30 @@ class ActionCommandPayload:
     target_object_or_agent: Optional[str] = None
     expected_outcome_summary: Optional[str] = None
 
+@dataclass
+class AttentionFocusUpdatePayload:
+    """
+    Payload for the Attention Module to communicate updates about its current focus.
+    """
+    focused_item_id: Optional[str] # ID of the item, concept, goal, or stimulus in focus
+    focus_type: str          # e.g., "goal_directed", "stimulus_driven", "internal_thought"
+    intensity: float         # How strongly focused (0.0 to 1.0)
+    source_trigger_message_id: Optional[str] = None # Optional ID of message that triggered this focus
+    timestamp: datetime.datetime = field(default_factory=lambda: datetime.datetime.now(datetime.timezone.utc))
+
+@dataclass
+class ToMInferenceUpdatePayload:
+    """
+    Payload for the Theory of Mind (ToM) Module to communicate its inferences
+    about other agents' mental states.
+    """
+    target_agent_id: str  # The agent whose mental state is being inferred
+    inferred_state_type: str  # e.g., "belief", "emotion", "intention", "desire"
+    inferred_state_value: Any # The actual inferred state or its description (e.g., {"emotion_type": "joy", "intensity": 0.7})
+    confidence: float         # Confidence in the inference (0.0 to 1.0)
+    source_evidence_ids: Optional[List[str]] = field(default_factory=list) # e.g., IDs of percepts, messages that led to this inference
+    timestamp: datetime.datetime = field(default_factory=lambda: datetime.datetime.now(datetime.timezone.utc))
+
 
 # Example EmotionalStateChangePayload (not explicitly requested by the prompt for this file)
 # @dataclass
@@ -206,5 +230,28 @@ if __name__ == '__main__':
     print(acp1)
     assert acp1.action_type == "MOVE_TO_LOCATION"
     assert acp1.priority == 0.5 # Default
+
+    # Test AttentionFocusUpdatePayload
+    afup1 = AttentionFocusUpdatePayload(
+        focused_item_id="goal_007",
+        focus_type="goal_directed",
+        intensity=0.85,
+        source_trigger_message_id="msg_abc"
+    )
+    print(afup1)
+    assert afup1.intensity == 0.85
+    assert isinstance(afup1.timestamp, datetime.datetime)
+
+    # Test ToMInferenceUpdatePayload
+    tom_inf1 = ToMInferenceUpdatePayload(
+        target_agent_id="user_A",
+        inferred_state_type="belief",
+        inferred_state_value="User A believes it is raining.",
+        confidence=0.7,
+        source_evidence_ids=["percept_id_rain_sound", "percept_id_user_statement"]
+    )
+    print(tom_inf1)
+    assert tom_inf1.confidence == 0.7
+    assert len(tom_inf1.source_evidence_ids) == 2
 
     print("\nCore messages example usage complete.")

--- a/PiaAGI_Research_Tools/PiaCML/tests/test_concrete_tom_module.py
+++ b/PiaAGI_Research_Tools/PiaCML/tests/test_concrete_tom_module.py
@@ -1,103 +1,205 @@
 import unittest
 import os
 import sys
+import datetime
+from unittest.mock import MagicMock, call
 
-# Adjust path to import from the parent directory (PiaCML)
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+# Adjust path for consistent imports
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..')))
 
 try:
+    from PiaAGI_Research_Tools.PiaCML import (
+        ConcreteTheoryOfMindModule,
+        MessageBus,
+        GenericMessage,
+        PerceptDataPayload,
+        ToMInferenceUpdatePayload
+        # EmotionalStateChangePayload is handled as dict for now
+    )
+except ModuleNotFoundError:
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
     from concrete_tom_module import ConcreteTheoryOfMindModule
-except ImportError:
-    # Fallback for different execution contexts
-    if 'ConcreteTheoryOfMindModule' not in globals():
-        from PiaAGI_Hub.PiaCML.concrete_tom_module import ConcreteTheoryOfMindModule
+    try:
+        from message_bus import MessageBus
+        from core_messages import GenericMessage, PerceptDataPayload, ToMInferenceUpdatePayload
+    except ImportError:
+        MessageBus = None
+        GenericMessage = None
+        PerceptDataPayload = None
+        ToMInferenceUpdatePayload = None
 
 class TestConcreteTheoryOfMindModule(unittest.TestCase):
 
     def setUp(self):
-        self.tom = ConcreteTheoryOfMindModule()
+        self.bus = MessageBus() if MessageBus else None
+        self.mock_bus = MagicMock(spec=MessageBus) if MessageBus else None
+
+        self.tom_no_bus = ConcreteTheoryOfMindModule()
+        self.tom_with_mock_bus = ConcreteTheoryOfMindModule(message_bus=self.mock_bus)
+        self.tom_with_real_bus = ConcreteTheoryOfMindModule(message_bus=self.bus)
+
         self._original_stdout = sys.stdout
-        sys.stdout = open(os.devnull, 'w')
+        # To see print statements from the module during tests, comment out the next line
+        # sys.stdout = open(os.devnull, 'w')
 
     def tearDown(self):
-        sys.stdout.close()
+        # sys.stdout.close()
         sys.stdout = self._original_stdout
 
-    def test_initial_get_agent_model(self):
-        self.assertIsNone(self.tom.get_agent_model("agent_x"))
+    # --- Tests for original direct-call methods (using tom_no_bus) ---
+    def test_initial_get_agent_model_no_bus(self):
+        self.assertIsNone(self.tom_no_bus.get_agent_model("agent_x"))
+        self.assertEqual(len(self.tom_no_bus.recent_inferences), 0)
 
-    def test_update_and_get_agent_model(self):
+
+    def test_update_and_get_agent_model_no_bus(self):
         agent_id = "agent_alpha"
         data1 = {"belief": "sky_is_blue"}
-        self.tom.update_agent_model(agent_id, data1)
-        model1 = self.tom.get_agent_model(agent_id)
+        self.tom_no_bus.update_agent_model(agent_id, data1)
+        model1 = self.tom_no_bus.get_agent_model(agent_id)
         self.assertIsNotNone(model1)
         self.assertEqual(model1['belief'], "sky_is_blue")
-        self.assertEqual(model1['interaction_count'], 0) # Defaulted by update
 
-        data2 = {"preference": "likes_rain", "interaction_count": 1}
-        self.tom.update_agent_model(agent_id, data2)
-        model2 = self.tom.get_agent_model(agent_id)
-        self.assertEqual(model2['belief'], "sky_is_blue") # Should merge, not overwrite all
-        self.assertEqual(model2['preference'], "likes_rain")
-        self.assertEqual(model2['interaction_count'], 1)
+    # --- New Tests for MessageBus Integration and Refactored infer_mental_state ---
 
-        # Test deep update for dictionaries
-        data3 = {"belief": {"weather": "sunny", "temperature": "warm"}}
-        self.tom.update_agent_model(agent_id, {"belief": {"weather": "cloudy"}})
-        model3 = self.tom.get_agent_model(agent_id)
-        self.assertEqual(model3['belief']['weather'], "cloudy") # existing dict updated
-        # self.assertNotIn('temperature', model3['belief']) # if it was a shallow update, this would fail
+    def test_initialization_with_bus_subscription(self):
+        """Test ToMModule initialization with a bus and subscriptions."""
+        if not MessageBus: self.skipTest("MessageBus components not available")
 
-    def test_infer_mental_state_new_agent_simple_desire(self):
-        agent_id = "agent_beta"
-        observables = {'utterance': "I really want that cookie!", 'expression': 'pointing', 'affective_cues': ['eager']}
-        inferred = self.tom.infer_mental_state(agent_id, observables)
+        self.assertIsNotNone(self.tom_with_real_bus.message_bus)
+        percept_subscribers = self.bus.get_subscribers_for_type("PerceptData")
+        emotion_subscribers = self.bus.get_subscribers_for_type("EmotionalStateChange")
 
-        self.assertIn('desire_state', inferred)
-        self.assertEqual(inferred['desire_state'].get('goal'), "obtain_cookie")
-        self.assertTrue(inferred['belief_state'].get("wants_cookie"))
-        self.assertEqual(inferred['confidence_of_inference'], 0.5) # Default for this rule
+        found_percept_sub = any(
+            s[0] == "ConcreteTheoryOfMindModule_01" and
+            s[1] == self.tom_with_real_bus.handle_percept_for_tom
+            for s in percept_subscribers if s
+        )
+        found_emotion_sub = any(
+            s[0] == "ConcreteTheoryOfMindModule_01" and
+            s[1] == self.tom_with_real_bus.handle_own_emotion_change_for_tom
+            for s in emotion_subscribers if s
+        )
+        self.assertTrue(found_percept_sub, "ToMModule did not subscribe to PerceptData.")
+        self.assertTrue(found_emotion_sub, "ToMModule did not subscribe to EmotionalStateChange.")
 
-        agent_model = self.tom.get_agent_model(agent_id)
-        self.assertIsNotNone(agent_model)
-        self.assertEqual(agent_model['interaction_count'], 1)
-        self.assertEqual(len(agent_model['inferred_mental_states_log']), 1)
+    def test_infer_mental_state_publishes_message(self):
+        """Test that infer_mental_state publishes a ToMInferenceUpdate message."""
+        if not all([MessageBus, GenericMessage, ToMInferenceUpdatePayload]):
+            self.skipTest("MessageBus or core message components not available")
 
-    def test_infer_mental_state_emotional_cue_happy(self):
-        agent_id = "agent_gamma"
-        observables = {'affective_cues': ['happy', 'laughing'], 'expression': 'smiling wide'}
-        inferred = self.tom.infer_mental_state(agent_id, observables)
-        self.assertEqual(inferred['emotional_state_inferred']['type'], 'positive_generic')
-        self.assertGreaterEqual(inferred['confidence_of_inference'], 0.4)
+        target_agent_id = "user_A"
+        evidence = "User A said: I am very happy today!"
+        state_to_infer = "emotion_happiness_conjecture"
 
-    def test_infer_mental_state_emotional_cue_sad(self):
-        agent_id = "agent_delta"
-        observables = {'utterance': "Oh no...", 'affective_cues': ['sad']}
-        inferred = self.tom.infer_mental_state(agent_id, observables)
-        self.assertEqual(inferred['emotional_state_inferred']['type'], 'negative_generic')
-        self.assertGreaterEqual(inferred['confidence_of_inference'], 0.4)
+        inference_payload = self.tom_with_mock_bus.infer_mental_state(target_agent_id, evidence, state_to_infer, "msg_evidence_1")
 
-    def test_infer_mental_state_no_specific_rules_hit(self):
-        agent_id = "agent_epsilon"
-        observables = {'utterance': "The sky is blue today."}
-        inferred = self.tom.infer_mental_state(agent_id, observables)
-        # Check default emotional state and low confidence
-        self.assertEqual(inferred['emotional_state_inferred']['type'], 'neutral')
-        self.assertEqual(inferred['confidence_of_inference'], 0.3)
-        # Check that an agent model was still created/updated
-        agent_model = self.tom.get_agent_model(agent_id)
-        self.assertIsNotNone(agent_model)
-        self.assertEqual(agent_model['interaction_count'], 1)
+        self.assertIsNotNone(inference_payload)
+        self.assertEqual(len(self.tom_with_mock_bus.recent_inferences), 1)
+        self.assertEqual(self.tom_with_mock_bus.recent_inferences[0], inference_payload)
+
+        self.mock_bus.publish.assert_called_once()
+        args, _ = self.mock_bus.publish.call_args
+        published_message: GenericMessage = args[0]
+
+        self.assertEqual(published_message.message_type, "ToMInferenceUpdate")
+        self.assertEqual(published_message.source_module_id, "ConcreteTheoryOfMindModule_01")
+
+        payload: ToMInferenceUpdatePayload = published_message.payload
+        self.assertIsInstance(payload, ToMInferenceUpdatePayload)
+        self.assertEqual(payload.target_agent_id, target_agent_id)
+        self.assertEqual(payload.inferred_state_type, state_to_infer)
+        self.assertEqual(payload.inferred_state_value, {"emotion": "happiness", "intensity_qualitative": "moderate"})
+        self.assertGreaterEqual(payload.confidence, 0.6)
+        self.assertIn("msg_evidence_1", payload.source_evidence_ids)
 
 
-    def test_multiple_inferences_update_log_and_count(self):
-        agent_id = "agent_zeta"
-        self.tom.infer_mental_state(agent_id, {'utterance': "First."})
-        self.tom.infer_mental_state(agent_id, {'utterance': "Second."})
-        agent_model = self.tom.get_agent_model(agent_id)
-        self.assertEqual(agent_model['interaction_count'], 2)
-        self.assertEqual(len(agent_model['inferred_mental_states_log']), 2)
+    def test_infer_mental_state_no_publish_if_no_bus(self):
+        """Test infer_mental_state does not attempt publish if no bus is configured."""
+        self.assertIsNone(self.tom_no_bus.message_bus)
+        self.tom_no_bus.infer_mental_state("user_B", "User B looks sad.", "emotion_sadness_conjecture")
+        # No direct way to check mock_bus wasn't called by tom_no_bus as it doesn't have it.
+        # This test relies on the internal `if self.message_bus:` check.
+        self.assertEqual(len(self.tom_no_bus.recent_inferences), 1) # Should still make inference locally.
+
+
+    def test_handle_percept_for_tom_triggers_inference_and_publish(self):
+        """Test PerceptData message triggers inference and subsequent ToMInferenceUpdate publish."""
+        if not all([MessageBus, GenericMessage, PerceptDataPayload, ToMInferenceUpdatePayload]):
+            self.skipTest("MessageBus or core message components not available")
+
+        # This mock will capture the ToMInferenceUpdate published by infer_mental_state
+        # when triggered by the percept handler in tom_with_real_bus.
+        mock_inference_listener = MagicMock(name="inference_listener")
+        self.bus.subscribe("InferenceListener", "ToMInferenceUpdate", mock_inference_listener)
+
+        percept_content = "User X mentioned they are feeling sad about the news."
+        percept_payload = PerceptDataPayload(
+            modality="text",
+            content=percept_content,
+            source_timestamp=datetime.datetime.now(datetime.timezone.utc),
+            percept_id="percept_sad_news_001"
+        )
+        percept_message = GenericMessage(
+            source_module_id="UserInteractionModule",
+            message_type="PerceptData",
+            payload=percept_payload,
+            message_id="msg_user_interaction_001"
+        )
+
+        self.bus.publish(percept_message) # This should trigger tom_with_real_bus.handle_percept_for_tom
+
+        self.assertIn(percept_payload, self.tom_with_real_bus.handled_percepts_for_tom)
+        self.assertGreaterEqual(len(self.tom_with_real_bus.recent_inferences), 1)
+
+        mock_inference_listener.assert_called_once()
+        received_inference_msg: GenericMessage = mock_inference_listener.call_args[0][0]
+        self.assertEqual(received_inference_msg.message_type, "ToMInferenceUpdate")
+
+        inference_payload_published: ToMInferenceUpdatePayload = received_inference_msg.payload
+        self.assertEqual(inference_payload_published.target_agent_id, "UserInteractionModule") # Based on current logic
+        self.assertEqual(inference_payload_published.inferred_state_type, "emotion_sadness_conjecture")
+        self.assertIn("msg_user_interaction_001", inference_payload_published.source_evidence_ids)
+        self.assertIn("percept_sad_news_001", inference_payload_published.source_evidence_ids)
+
+
+    def test_handle_own_emotion_change_for_tom(self):
+        """Test ToMModule handles agent's own EmotionalStateChange messages."""
+        if not MessageBus or not GenericMessage:
+            self.skipTest("MessageBus or GenericMessage not available")
+
+        own_emotion_payload = {"valence": -0.8, "arousal": 0.7, "dominance": -0.2} # e.g., agent is feeling fear/distress
+        emotion_message = GenericMessage(
+            source_module_id="OwnEmotionModule", # Should be agent's own emotion module
+            message_type="EmotionalStateChange",
+            payload=own_emotion_payload
+        )
+
+        self.bus.publish(emotion_message)
+        self.assertIn(own_emotion_payload, self.tom_with_real_bus.handled_own_emotions_for_tom)
+        # Further tests could check if this state biases future inferences, once that logic exists.
+
+    def test_handle_percept_unexpected_payload(self):
+        """Test ToM handles PerceptData message with an unexpected payload type."""
+        if not MessageBus or not GenericMessage:
+            self.skipTest("MessageBus or GenericMessage not available")
+
+        malformed_msg = GenericMessage(
+            source_module_id="TestMalformedSource",
+            message_type="PerceptData",
+            payload="This is not a PerceptDataPayload"
+        )
+
+        # Suppress print for this specific test of error path
+        original_stdout_test = sys.stdout
+        sys.stdout = open(os.devnull, 'w')
+        self.bus.publish(malformed_msg)
+        sys.stdout.close()
+        sys.stdout = original_stdout_test
+
+        self.assertEqual(len(self.tom_with_real_bus.handled_percepts_for_tom), 0)
+        self.assertEqual(len(self.tom_with_real_bus.recent_inferences), 0)
+
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main(argv=['first-arg-is-ignored'], exit=False)

--- a/ToDoList.md
+++ b/ToDoList.md
@@ -196,6 +196,8 @@ This section outlines proposed future development directions for the PiaAGI Rese
     - [x] Integrated Message Bus with `ConcretePlanningAndDecisionMakingModule` to subscribe to "GoalUpdate" messages and publish "ActionCommand" messages. (Completed on 2024-03-08 by Jules)
     - [x] Integrated Message Bus with `ConcreteBehaviorGenerationModule` to subscribe to "ActionCommand" messages. (Completed on 2024-03-08 by Jules)
     - [x] Integrated Message Bus with `ConcreteLearningModule` to subscribe to "GoalUpdate" messages for learning purposes. (Completed on 2024-03-08 by Jules)
+    - [x] Conceptually integrated Message Bus with `ConcreteAttentionModule` (publishes "AttentionFocusUpdate", subscribes to "GoalUpdate" & "EmotionalStateChange"). (Completed on 2024-03-08 by Jules)
+    - [x] Conceptually integrated Message Bus with `ConcreteTheoryOfMindModule` (publishes "ToMInferenceUpdate", subscribes to "PerceptData" & "EmotionalStateChange"). (Completed on 2024-03-08 by Jules)
 - [x] **Proof-of-Concept for an Architectural Maturation Hook:** Implement a basic mechanism for one of the conceptualized hooks (e.g., dynamic WM capacity adjustment) in a relevant module prototype. (Completed on 2024-03-08 by Jules)
 
 ### PiaSE (PiaAGI Simulation Environment) - Enhancements


### PR DESCRIPTION
…M Modules

This commit introduces new core message types for attention and Theory of Mind (ToM) updates, and conceptually integrates the MessageBus with the ConcreteAttentionModule and ConcreteTheoryOfMindModule.

Key changes:

1.  **Core Messages (`core_messages.py`, `__init__.py`, `tests/test_core_messages.py`):**
    *   Defined `AttentionFocusUpdatePayload` for broadcasting updates to
        my attentional focus.
    *   Defined `ToMInferenceUpdatePayload` for publishing inferences made
        by the ToM module about other agents.
    *   Updated package `__init__.py` to export these new types.
    *   Added unit tests for the new payload dataclasses.

2.  **ConcreteAttentionModule:**
    *   Updated to accept an optional `MessageBus` instance.
    *   The `set_attention_focus` method now publishes an
        "AttentionFocusUpdate" message if a bus is configured.
    *   Subscribes to "GoalUpdate" and "EmotionalStateChange" messages,
        with handlers that conceptually adjust attention based on these inputs
        (triggering a new "AttentionFocusUpdate").
    *   Unit tests updated/added to verify these message-based interactions.

3.  **ConcreteTheoryOfMindModule:**
    *   Updated to accept an optional `MessageBus` instance.
    *   The `infer_mental_state` method now publishes a "ToMInferenceUpdate"
        message if a bus is configured.
    *   Subscribes to "PerceptData" and "EmotionalStateChange" messages.
        Handlers conceptually process these for ToM updates, with the
        percept handler triggering new inferences and publications.
    *   Unit tests updated/added to verify message-based interactions.

The `ToDoList.md` has been updated to reflect these conceptual integrations as part of the ongoing Phase 2 development of the communication system.