### PR TITLE
Enhance PiaSE DSE to support environment and agent reconfiguration.

### DIFF
--- a/PiaAGI_Research_Tools/PiaSE/core_engine/interfaces.py
+++ b/PiaAGI_Research_Tools/PiaSE/core_engine/interfaces.py
@@ -134,6 +134,24 @@ class Environment(ABC):
         """
         pass
 
+    @abstractmethod
+    def reconfigure(self, config: Dict[str, Any]) -> bool:
+        """
+        Reconfigures the environment based on the provided configuration dictionary.
+        This allows for dynamic changes to the environment's parameters, layout,
+        or other characteristics during a simulation run, often guided by a
+        Dynamic Scenario Engine (DSE) or a curriculum.
+
+        Args:
+            config (Dict[str, Any]): A dictionary containing the configuration parameters
+                                     to apply. The specific keys and values expected
+                                     will depend on the concrete environment implementation.
+
+        Returns:
+            bool: True if the reconfiguration was successful and applied, False otherwise.
+        """
+        pass
+
 class AgentInterface(ABC):
     """
     Abstract base class for an agent.

--- a/PiaAGI_Research_Tools/PiaSE/environments/text_based_room.py
+++ b/PiaAGI_Research_Tools/PiaSE/environments/text_based_room.py
@@ -383,4 +383,56 @@ class TextBasedRoom(Environment):
             }
         }
 
+    def reconfigure(self, config: Dict[str, Any]) -> bool:
+        """
+        Reconfigures the TextBasedRoom environment based on the provided configuration.
+        This primarily allows for changing the initial room layout, object details,
+        and agent starting room.
+        """
+        print(f"TextBasedRoom: Attempting reconfiguration with: {list(config.keys())}")
+        reconfigured_something = False
+
+        if "room_layout" in config:
+            if isinstance(config["room_layout"], dict):
+                self.base_room_layout = copy.deepcopy(config["room_layout"])
+                print("  Reconfigured base_room_layout.")
+                reconfigured_something = True
+            else:
+                print("  TextBasedRoom Warning: 'room_layout' in reconfigure must be a dictionary. Not applied.")
+
+        if "object_details" in config:
+            if isinstance(config["object_details"], dict):
+                self.base_object_details = copy.deepcopy(config["object_details"])
+                print("  Reconfigured base_object_details.")
+                reconfigured_something = True
+            else:
+                print("  TextBasedRoom Warning: 'object_details' in reconfigure must be a dictionary. Not applied.")
+
+        if "agent_start_room" in config:
+            if isinstance(config["agent_start_room"], str):
+                # Further validation if this room exists in the new layout could be added,
+                # but reset() will handle initial placement observation.
+                self.agent_start_room = config["agent_start_room"]
+                print(f"  Reconfigured agent_start_room to: {self.agent_start_room}")
+                reconfigured_something = True
+            else:
+                print("  TextBasedRoom Warning: 'agent_start_room' in reconfigure must be a string. Not applied.")
+
+        # Action schema could also be made reconfigurable if needed, but for now, it's fixed.
+        # if "action_schema" in config:
+        #     if isinstance(config["action_schema"], dict):
+        #         self.action_schema = copy.deepcopy(config["action_schema"])
+        #         print("  Reconfigured action_schema.")
+        #         reconfigured_something = True
+        #     else:
+        #         print("  TextBasedRoom Warning: 'action_schema' in reconfigure must be a dictionary. Not applied.")
+
+        if reconfigured_something:
+            print("TextBasedRoom: Calling reset() after reconfiguration.")
+            self.reset() # Apply changes by resetting the environment state
+        else:
+            print("TextBasedRoom: No applicable configuration changes found or applied.")
+
+        return True # Indicate reconfiguration attempt was processed
+
 ```


### PR DESCRIPTION
This commit implements Item 10 from IMPROVEMENT_TODOLIST.md: "[ENHANCEMENT] PiaSE DSE Environment Reconfiguration."

Changes include:
1.  **`core_engine/interfaces.py`**:
    *   I added a `reconfigure(self, config: Dict[str, Any]) -> bool` abstract method to the `Environment` ABC to allow dynamic environment updates.

2.  **`environments/grid_world.py` & `environments/text_based_room.py`**:
    *   I implemented the `reconfigure` method in `GridWorld` to update goal, walls, objects, start position, and rewards.
    *   I implemented the `reconfigure` method in `TextBasedRoom` to update base layout, object details, and agent start room.
    *   Both methods call `self.reset()` after applying configurations.

3.  **`core_engine/basic_engine.py`**:
    *   I enhanced the DSE loop in `run_simulation` to check for `environment_config` in the current curriculum step and call `self.environment.reconfigure()` if present.
    *   I added logic to also check for `agent_config_overrides` in the curriculum step and call `agent.configure(config=...)` if the agent has a `configure` method.
    *   I added logging for these reconfiguration attempts and outcomes.

4.  **`scenarios/dynamic_scaffolding_scenario.py`**:
    *   I updated `RuleBasedGridAgent.configure` to accept a general `config` dictionary from which `motivation_config` is extracted.
    *   I refined the `interaction_step_with_avt_update` hook to dynamically use the current DSE step's goal coordinates (from `agent_config_overrides`) for determining mock AVT success metrics.
    *   I added initial print statements to help verify pre-DSE state.

These changes enable the Dynamic Scenario Engine to modify both the environment and agent parameters at each step of a curriculum, significantly enhancing its capability for developmental scaffolding.